### PR TITLE
Improve schedule generation and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Wielren Schema App</title>
   </head>
-  <body>
+  <body class="min-h-screen bg-gradient-to-br from-emerald-200 via-sky-200 to-fuchsia-200">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/SchemaView.jsx
+++ b/src/SchemaView.jsx
@@ -1,4 +1,4 @@
-function generateSchema({ level, days, ftp }) {
+function generateSchema({ level, days }) {
   const planByLevel = {
     beginner: [
       { type: 'warmup', minutes: 10, factor: 0.55 },
@@ -18,13 +18,21 @@ function generateSchema({ level, days, ftp }) {
   };
 
   const schema = [];
-  for (let i = 0; i < days; i++) {
-    const baseBlocks = planByLevel[level];
-    schema.push({
-      day: `Dag ${i + 1}`,
-      title: `Trainingsblok ${i + 1}`,
-      blocks: baseBlocks,
-    });
+  const weeks = 6;
+  for (let w = 0; w < weeks; w++) {
+    for (let d = 0; d < days; d++) {
+      const baseBlocks = planByLevel[level].map((b) => ({
+        ...b,
+        minutes: Math.round(b.minutes * (1 + w * 0.1)),
+        factor: parseFloat((b.factor + w * 0.02).toFixed(2)),
+      }));
+
+      schema.push({
+        day: `Week ${w + 1} - Dag ${d + 1}`,
+        title: `Training ${d + 1}`,
+        blocks: baseBlocks,
+      });
+    }
   }
   return schema;
 }
@@ -94,8 +102,8 @@ export default function SchemaView({ intake, onUpdateFtp }) {
   const schema = generateSchema(intake);
 
   return (
-    <div className="min-h-screen bg-gray-100 p-6">
-      <div className="max-w-3xl mx-auto bg-white shadow rounded-lg p-6 space-y-6">
+    <div className="min-h-screen p-6">
+      <div className="max-w-3xl mx-auto bg-white/90 shadow rounded-lg p-6 space-y-6">
         <h1 className="text-3xl font-bold text-gray-800">Trainingsschema</h1>
         <p className="text-gray-600">
           Niveau: <strong>{intake.level}</strong> · Dagen/week: <strong>{intake.days}</strong> · FTP: <strong>{intake.ftp} watt</strong>
@@ -103,7 +111,7 @@ export default function SchemaView({ intake, onUpdateFtp }) {
 
         <div className="grid gap-4">
           {schema.map((item, index) => (
-            <div key={index} className="bg-blue-50 p-4 rounded shadow-sm border border-blue-200">
+            <div key={index} className="bg-blue-50/60 p-4 rounded shadow-sm border border-blue-200">
               <h2 className="text-xl font-semibold text-blue-800">{item.day}</h2>
               <p className="text-gray-700 mb-2">Trainingsvorm: <strong>{item.title}</strong></p>
               <ul className="list-disc ml-5 text-gray-600">
@@ -117,7 +125,7 @@ export default function SchemaView({ intake, onUpdateFtp }) {
               </ul>
               <button
                 onClick={() => downloadTcx(item.title, item.blocks, intake.ftp)}
-                className="mt-3 inline-block bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+                className="mt-3 inline-block bg-gradient-to-r from-emerald-500 to-sky-500 text-white px-4 py-2 rounded hover:from-emerald-600 hover:to-sky-600"
               >
                 Download .TCX
               </button>
@@ -129,7 +137,7 @@ export default function SchemaView({ intake, onUpdateFtp }) {
           <label className="block text-gray-700 font-medium mb-1">Update je FTP:</label>
           <input
             type="number"
-            className="w-full border border-gray-300 p-2 rounded"
+            className="w-full border border-gray-300 p-2 rounded bg-white/70"
             placeholder="Nieuwe FTP"
             onChange={(e) => onUpdateFtp(parseInt(e.target.value))}
           />

--- a/src/TrainingIntake.jsx
+++ b/src/TrainingIntake.jsx
@@ -12,10 +12,10 @@ export default function TrainingIntake({ onComplete }) {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <div className="min-h-screen flex items-center justify-center">
       <form
         onSubmit={handleSubmit}
-        className="bg-white p-8 rounded shadow-md w-full max-w-md space-y-6"
+        className="bg-white/90 p-8 rounded shadow-md w-full max-w-md space-y-6"
       >
         <h2 className="text-2xl font-bold text-center text-gray-700">Trainingsintake</h2>
 
@@ -56,7 +56,7 @@ export default function TrainingIntake({ onComplete }) {
 
         <button
           type="submit"
-          className="w-full bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600"
+          className="w-full bg-gradient-to-r from-emerald-500 to-sky-500 text-white py-2 px-4 rounded hover:from-emerald-600 hover:to-sky-600"
         >
           Genereer Schema
         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply bg-gradient-to-br from-emerald-200 via-sky-200 to-fuchsia-200;
+}


### PR DESCRIPTION
## Summary
- design gradient background and brand colors
- add gradient-themed UI styling
- generate 6-week training schedules with progressive difficulty

## Testing
- `npm run build` *(fails: vite not found)*