### PR TITLE
Enhance schema generator with email intake and styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Wielren Schema App
+
+This project generates six-week cycling training plans using React, Vite and Tailwind CSS.
+
+## Setup
+
+1. Install Node.js and npm.
+2. Install dependencies:
+   ```sh
+   npm install
+   ```
+3. Start the development server:
+   ```sh
+   npm run dev
+   ```
+4. Build for production:
+   ```sh
+   npm run build
+   ```
+
+Open `index.html` via the dev server to see the app. The schedule requires an e-mail address before generating.

--- a/index.css
+++ b/index.css
@@ -1,3 +1,0 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;

--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Wielren Schema App</title>
   </head>
-  <body>
+  <body class="min-h-screen bg-gradient-to-br from-purple-700 via-purple-900 to-black">
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>

--- a/src/SchemaView.jsx
+++ b/src/SchemaView.jsx
@@ -1,30 +1,76 @@
-function generateSchema({ level, days, ftp }) {
+function generateSchema({ level, days }) {
   const planByLevel = {
     beginner: [
-      { type: 'warmup', minutes: 10, factor: 0.55 },
-      { type: 'endurance', minutes: 30, factor: 0.65 },
-      { type: 'cooldown', minutes: 5, factor: 0.5 },
+      [
+        { type: 'warmup', minutes: 10, factor: 0.55 },
+        { type: 'endurance', minutes: 30, factor: 0.65 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      [
+        { type: 'warmup', minutes: 10, factor: 0.55 },
+        { type: 'tempo', minutes: 20, factor: 0.75 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      [
+        { type: 'warmup', minutes: 10, factor: 0.55 },
+        { type: 'interval', minutes: 3, repeats: 4, rest: 2, factor: 0.9, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
     ],
     intermediate: [
-      { type: 'warmup', minutes: 10, factor: 0.6 },
-      { type: 'interval', minutes: 5, factor: 1.05, repeats: 4, rest: 3, restFactor: 0.6 },
-      { type: 'cooldown', minutes: 5, factor: 0.5 },
+      [
+        { type: 'warmup', minutes: 10, factor: 0.6 },
+        { type: 'interval', minutes: 5, repeats: 4, rest: 3, factor: 1.05, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      [
+        { type: 'warmup', minutes: 10, factor: 0.6 },
+        { type: 'tempo', minutes: 30, factor: 0.8 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      [
+        { type: 'warmup', minutes: 10, factor: 0.6 },
+        { type: 'endurance', minutes: 40, factor: 0.7 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
     ],
     advanced: [
-      { type: 'warmup', minutes: 10, factor: 0.65 },
-      { type: 'interval', minutes: 6, factor: 1.1, repeats: 5, rest: 3, restFactor: 0.6 },
-      { type: 'cooldown', minutes: 5, factor: 0.5 },
+      [
+        { type: 'warmup', minutes: 10, factor: 0.65 },
+        { type: 'interval', minutes: 6, repeats: 5, rest: 3, factor: 1.1, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      [
+        { type: 'warmup', minutes: 10, factor: 0.65 },
+        { type: 'tempo', minutes: 40, factor: 0.85 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      [
+        { type: 'warmup', minutes: 10, factor: 0.65 },
+        { type: 'endurance', minutes: 60, factor: 0.75 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
     ],
   };
 
   const schema = [];
-  for (let i = 0; i < days; i++) {
-    const baseBlocks = planByLevel[level];
-    schema.push({
-      day: `Dag ${i + 1}`,
-      title: `Trainingsblok ${i + 1}`,
-      blocks: baseBlocks,
-    });
+  const weeks = 6;
+  const variations = planByLevel[level];
+  for (let w = 0; w < weeks; w++) {
+    for (let d = 0; d < days; d++) {
+      const variant = variations[(w + d) % variations.length];
+      const baseBlocks = variant.map((b) => ({
+        ...b,
+        minutes: Math.round(b.minutes * (1 + w * 0.1)),
+        factor: parseFloat((b.factor + w * 0.02).toFixed(2)),
+      }));
+
+      schema.push({
+        day: `Week ${w + 1} - Dag ${d + 1}`,
+        title: `Training ${d + 1}`,
+        blocks: baseBlocks,
+      });
+    }
   }
   return schema;
 }
@@ -94,16 +140,17 @@ export default function SchemaView({ intake, onUpdateFtp }) {
   const schema = generateSchema(intake);
 
   return (
-    <div className="min-h-screen bg-gray-100 p-6">
-      <div className="max-w-3xl mx-auto bg-white shadow rounded-lg p-6 space-y-6">
+    <div className="min-h-screen p-6">
+      <div className="max-w-3xl mx-auto bg-white/90 shadow rounded-lg p-6 space-y-6">
         <h1 className="text-3xl font-bold text-gray-800">Trainingsschema</h1>
         <p className="text-gray-600">
           Niveau: <strong>{intake.level}</strong> · Dagen/week: <strong>{intake.days}</strong> · FTP: <strong>{intake.ftp} watt</strong>
         </p>
+        <p className="text-gray-500 text-sm">E-mail: {intake.email}</p>
 
         <div className="grid gap-4">
           {schema.map((item, index) => (
-            <div key={index} className="bg-blue-50 p-4 rounded shadow-sm border border-blue-200">
+            <div key={index} className="bg-blue-50/60 p-4 rounded shadow-sm border border-blue-200">
               <h2 className="text-xl font-semibold text-blue-800">{item.day}</h2>
               <p className="text-gray-700 mb-2">Trainingsvorm: <strong>{item.title}</strong></p>
               <ul className="list-disc ml-5 text-gray-600">
@@ -117,7 +164,7 @@ export default function SchemaView({ intake, onUpdateFtp }) {
               </ul>
               <button
                 onClick={() => downloadTcx(item.title, item.blocks, intake.ftp)}
-                className="mt-3 inline-block bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+                className="mt-3 inline-block bg-gradient-to-r from-purple-600 to-black text-white px-4 py-2 rounded hover:from-purple-700 hover:to-gray-900"
               >
                 Download .TCX
               </button>
@@ -129,7 +176,7 @@ export default function SchemaView({ intake, onUpdateFtp }) {
           <label className="block text-gray-700 font-medium mb-1">Update je FTP:</label>
           <input
             type="number"
-            className="w-full border border-gray-300 p-2 rounded"
+            className="w-full border border-gray-300 p-2 rounded bg-white/70"
             placeholder="Nieuwe FTP"
             onChange={(e) => onUpdateFtp(parseInt(e.target.value))}
           />

--- a/src/TrainingIntake.jsx
+++ b/src/TrainingIntake.jsx
@@ -4,18 +4,24 @@ export default function TrainingIntake({ onComplete }) {
   const [level, setLevel] = useState('beginner');
   const [days, setDays] = useState(3);
   const [ftp, setFtp] = useState('');
+  const [email, setEmail] = useState('');
 
   const handleSubmit = (e) => {
     e.preventDefault();
     const parsedFtp = parseInt(ftp);
-    onComplete({ level, days, ftp: isNaN(parsedFtp) ? 200 : parsedFtp });
+    onComplete({
+      level,
+      days,
+      ftp: isNaN(parsedFtp) ? 200 : parsedFtp,
+      email,
+    });
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <div className="min-h-screen flex items-center justify-center">
       <form
         onSubmit={handleSubmit}
-        className="bg-white p-8 rounded shadow-md w-full max-w-md space-y-6"
+        className="bg-white/90 p-8 rounded shadow-md w-full max-w-md space-y-6"
       >
         <h2 className="text-2xl font-bold text-center text-gray-700">Trainingsintake</h2>
 
@@ -54,9 +60,20 @@ export default function TrainingIntake({ onComplete }) {
           />
         </div>
 
+        <div>
+          <label className="block text-gray-600 mb-1">E-mail:</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="w-full border border-gray-300 p-2 rounded"
+          />
+        </div>
+
         <button
           type="submit"
-          className="w-full bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600"
+          className="w-full bg-gradient-to-r from-purple-600 to-black text-white py-2 px-4 rounded hover:from-purple-700 hover:to-gray-900"
         >
           Genereer Schema
         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply bg-gradient-to-br from-purple-700 via-purple-900 to-black;
+}


### PR DESCRIPTION
## Summary
- require e-mail before generating a program
- rotate workout blocks weekly for more variety
- switch gradients to purple & black
- remove unused root stylesheet
- document setup instructions in README

## Testing
- `npm run build` *(fails: vite not found)*