### PR TITLE
Improve schedule generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Wielren Schema App
+
+Een eenvoudige React-app om een gratis zes-weeks trainingsschema te genereren voor beginnende en gevorderde wielrenners. De app gebruikt Vite en TailwindCSS.
+
+## Installatie
+1. Zorg dat Node.js en npm zijn geïnstalleerd.
+2. Installeer de packages:
+   ```bash
+   npm install
+   ```
+3. Start de ontwikkelserver:
+   ```bash
+   npm run dev
+   ```
+4. Bezoek `http://localhost:5173` in de browser.
+
+## Bouw
+Een productie-build kan aangemaakt worden met:
+```bash
+npm run build
+```
+
+(Deze omgeving bevat Vite niet, dus de build zal hier falen.)
+

--- a/index.css
+++ b/index.css
@@ -1,3 +1,0 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Wielren Schema App</title>
   </head>
-  <body>
+  <body class="min-h-screen bg-gradient-to-br from-purple-900 via-purple-700 to-black">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/SchemaView.jsx
+++ b/src/SchemaView.jsx
@@ -1,30 +1,36 @@
-function generateSchema({ level, days, ftp }) {
-  const planByLevel = {
-    beginner: [
-      { type: 'warmup', minutes: 10, factor: 0.55 },
-      { type: 'endurance', minutes: 30, factor: 0.65 },
-      { type: 'cooldown', minutes: 5, factor: 0.5 },
-    ],
-    intermediate: [
-      { type: 'warmup', minutes: 10, factor: 0.6 },
-      { type: 'interval', minutes: 5, factor: 1.05, repeats: 4, rest: 3, restFactor: 0.6 },
-      { type: 'cooldown', minutes: 5, factor: 0.5 },
-    ],
-    advanced: [
-      { type: 'warmup', minutes: 10, factor: 0.65 },
-      { type: 'interval', minutes: 6, factor: 1.1, repeats: 5, rest: 3, restFactor: 0.6 },
-      { type: 'cooldown', minutes: 5, factor: 0.5 },
-    ],
-  };
-
+function generateSchema({ level, days, minutes }) {
   const schema = [];
-  for (let i = 0; i < days; i++) {
-    const baseBlocks = planByLevel[level];
-    schema.push({
-      day: `Dag ${i + 1}`,
-      title: `Trainingsblok ${i + 1}`,
-      blocks: baseBlocks,
-    });
+  const weeks = 6;
+
+  const enduranceFactor = level === 'beginner' ? 0.6 : level === 'intermediate' ? 0.65 : 0.7;
+  const intervalFactor = level === 'beginner' ? 1.0 : level === 'intermediate' ? 1.05 : 1.1;
+
+  for (let w = 0; w < weeks; w++) {
+    const weekMinutes = minutes * (1 + w * 0.1);
+    for (let d = 0; d < days; d++) {
+      const isIntensityDay = d === days - 1; // roughly 80/20 split
+      let blocks;
+      if (isIntensityDay) {
+        blocks = [
+          { type: 'warmup', minutes: 10, factor: enduranceFactor - 0.05 },
+          { type: 'interval', minutes: 5, factor: intervalFactor, repeats: 3 + w, rest: 3, restFactor: enduranceFactor - 0.1 },
+          { type: 'cooldown', minutes: 5, factor: enduranceFactor - 0.05 },
+        ];
+      } else {
+        const enduranceMinutes = Math.max(20, weekMinutes - 15);
+        blocks = [
+          { type: 'warmup', minutes: 10, factor: enduranceFactor - 0.05 },
+          { type: 'endurance', minutes: enduranceMinutes, factor: enduranceFactor },
+          { type: 'cooldown', minutes: 5, factor: enduranceFactor - 0.05 },
+        ];
+      }
+
+      schema.push({
+        day: `Week ${w + 1} - Dag ${d + 1}`,
+        title: isIntensityDay ? 'Intervaltraining' : 'Duurtraining',
+        blocks,
+      });
+    }
   }
   return schema;
 }
@@ -94,16 +100,18 @@ export default function SchemaView({ intake, onUpdateFtp }) {
   const schema = generateSchema(intake);
 
   return (
-    <div className="min-h-screen bg-gray-100 p-6">
-      <div className="max-w-3xl mx-auto bg-white shadow rounded-lg p-6 space-y-6">
+    <div className="min-h-screen p-6">
+      <div className="max-w-3xl mx-auto bg-white/90 shadow rounded-lg p-6 space-y-6">
         <h1 className="text-3xl font-bold text-gray-800">Trainingsschema</h1>
         <p className="text-gray-600">
           Niveau: <strong>{intake.level}</strong> · Dagen/week: <strong>{intake.days}</strong> · FTP: <strong>{intake.ftp} watt</strong>
         </p>
+        <p className="text-gray-600">Email: <strong>{intake.email}</strong></p>
+        <p className="text-gray-600">Minuten per training: <strong>{intake.minutes}</strong></p>
 
         <div className="grid gap-4">
           {schema.map((item, index) => (
-            <div key={index} className="bg-blue-50 p-4 rounded shadow-sm border border-blue-200">
+            <div key={index} className="bg-blue-50/60 p-4 rounded shadow-sm border border-blue-200">
               <h2 className="text-xl font-semibold text-blue-800">{item.day}</h2>
               <p className="text-gray-700 mb-2">Trainingsvorm: <strong>{item.title}</strong></p>
               <ul className="list-disc ml-5 text-gray-600">
@@ -117,7 +125,7 @@ export default function SchemaView({ intake, onUpdateFtp }) {
               </ul>
               <button
                 onClick={() => downloadTcx(item.title, item.blocks, intake.ftp)}
-                className="mt-3 inline-block bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+                className="mt-3 inline-block bg-gradient-to-r from-purple-600 to-black text-white px-4 py-2 rounded hover:from-purple-700 hover:to-gray-800"
               >
                 Download .TCX
               </button>
@@ -129,7 +137,7 @@ export default function SchemaView({ intake, onUpdateFtp }) {
           <label className="block text-gray-700 font-medium mb-1">Update je FTP:</label>
           <input
             type="number"
-            className="w-full border border-gray-300 p-2 rounded"
+            className="w-full border border-gray-300 p-2 rounded bg-white/70"
             placeholder="Nieuwe FTP"
             onChange={(e) => onUpdateFtp(parseInt(e.target.value))}
           />

--- a/src/TrainingIntake.jsx
+++ b/src/TrainingIntake.jsx
@@ -4,18 +4,26 @@ export default function TrainingIntake({ onComplete }) {
   const [level, setLevel] = useState('beginner');
   const [days, setDays] = useState(3);
   const [ftp, setFtp] = useState('');
+  const [email, setEmail] = useState('');
+  const [minutes, setMinutes] = useState(60);
 
   const handleSubmit = (e) => {
     e.preventDefault();
     const parsedFtp = parseInt(ftp);
-    onComplete({ level, days, ftp: isNaN(parsedFtp) ? 200 : parsedFtp });
+    onComplete({
+      level,
+      days,
+      ftp: isNaN(parsedFtp) ? 200 : parsedFtp,
+      email,
+      minutes: Number(minutes) || 60,
+    });
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <div className="min-h-screen flex items-center justify-center">
       <form
         onSubmit={handleSubmit}
-        className="bg-white p-8 rounded shadow-md w-full max-w-md space-y-6"
+        className="bg-white/90 p-8 rounded shadow-md w-full max-w-md space-y-6"
       >
         <h2 className="text-2xl font-bold text-center text-gray-700">Trainingsintake</h2>
 
@@ -54,9 +62,32 @@ export default function TrainingIntake({ onComplete }) {
           />
         </div>
 
+        <div>
+          <label className="block text-gray-600 mb-1">Emailadres:</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="w-full border border-gray-300 p-2 rounded"
+          />
+        </div>
+
+        <div>
+          <label className="block text-gray-600 mb-1">Minuten per training:</label>
+          <input
+            type="number"
+            value={minutes}
+            onChange={(e) => setMinutes(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded"
+            min="30"
+            max="240"
+          />
+        </div>
+
         <button
           type="submit"
-          className="w-full bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600"
+          className="w-full bg-gradient-to-r from-purple-600 to-black text-white py-2 px-4 rounded hover:from-purple-700 hover:to-gray-800"
         >
           Genereer Schema
         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply bg-gradient-to-br from-purple-900 via-purple-700 to-black;
+}


### PR DESCRIPTION
## Summary
- adopt purple/black gradient theme
- remove unused root stylesheet
- require email and available minutes before generating plan
- generate 6-week polarized training schedule based on input minutes
- document local setup in README

## Testing
- `npm run build` *(fails: vite not found)*