### PR TITLE
Enable browser execution

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,362 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Wielren Schema App</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   </head>
-  <body>
+  <body class="min-h-screen bg-gradient-to-b from-purple-800 to-black">
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="text/babel">
+      const { useState } = React;
+
+      function TrainingIntake({ onComplete }) {
+        const [level, setLevel] = useState("beginner");
+        const [days, setDays] = useState(3);
+        const [ftp, setFtp] = useState("");
+        const [hours, setHours] = useState("");
+        const [email, setEmail] = useState("");
+
+        const handleSubmit = (e) => {
+          e.preventDefault();
+          const parsedFtp = parseInt(ftp);
+          const parsedHours = parseFloat(hours);
+          if (!email) {
+            alert("E-mailadres is verplicht");
+            return;
+          }
+          onComplete({
+            level,
+            days,
+            hours: isNaN(parsedHours) ? 5 : parsedHours,
+            ftp: isNaN(parsedFtp) ? 200 : parsedFtp,
+            email,
+          });
+        };
+
+        return (
+          <div className="min-h-screen flex items-center justify-center">
+            <form
+              onSubmit={handleSubmit}
+              className="bg-white p-8 rounded shadow-md w-full max-w-md space-y-6"
+            >
+              <h1 className="text-3xl font-bold text-center text-purple-700">
+                Gratis 6 Weken Trainingsschema
+              </h1>
+              <p className="text-gray-600 text-center">
+                Ontvang een gepersonaliseerd schema op basis van je FTP en
+                beschikbare tijd.
+              </p>
+
+              <div>
+                <label className="block text-gray-600 mb-1">Niveau:</label>
+                <select
+                  value={level}
+                  onChange={(e) => setLevel(e.target.value)}
+                  className="w-full border border-gray-300 p-2 rounded"
+                >
+                  <option value="beginner">Beginner</option>
+                  <option value="intermediate">Gevorderd</option>
+                  <option value="advanced">Expert</option>
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-gray-600 mb-1">Dagen per week:</label>
+                <input
+                  type="number"
+                  value={days}
+                  onChange={(e) => setDays(Number(e.target.value))}
+                  className="w-full border border-gray-300 p-2 rounded"
+                  min="1"
+                  max="7"
+                />
+              </div>
+
+              <div>
+                <label className="block text-gray-600 mb-1">FTP:</label>
+                <input
+                  type="number"
+                  value={ftp}
+                  onChange={(e) => setFtp(e.target.value)}
+                  className="w-full border border-gray-300 p-2 rounded"
+                />
+              </div>
+
+              <div>
+                <label className="block text-gray-600 mb-1"
+                  >Uren beschikbaar per week:</label
+                >
+                <input
+                  type="number"
+                  value={hours}
+                  onChange={(e) => setHours(e.target.value)}
+                  className="w-full border border-gray-300 p-2 rounded"
+                  min="1"
+                  step="0.5"
+                />
+              </div>
+
+              <div>
+                <label className="block text-gray-600 mb-1">E-mailadres:</label>
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="w-full border border-gray-300 p-2 rounded"
+                  required
+                />
+              </div>
+
+              <button
+                type="submit"
+                className="w-full bg-purple-600 text-white py-2 px-4 rounded hover:bg-purple-700"
+              >
+                Genereer Schema
+              </button>
+            </form>
+          </div>
+        );
+      }
+
+      function totalMinutes(blocks) {
+        return blocks.reduce((sum, b) => {
+          if (b.type === "interval") {
+            return sum + b.repeats * (b.minutes + b.rest);
+          }
+          return sum + b.minutes;
+        }, 0);
+      }
+
+      function scaleBlocks(blocks, target) {
+        const base = totalMinutes(blocks);
+        const ratio = target / base;
+        return blocks.map((b) => {
+          const scaled = { ...b };
+          scaled.minutes = Math.round(b.minutes * ratio);
+          if (b.rest) scaled.rest = Math.round(b.rest * ratio);
+          return scaled;
+        });
+      }
+
+      function generateSchema({ level, days, ftp, hours }) {
+        const plans = {
+          beginner: {
+            endurance: [
+              { type: "warmup", minutes: 10, factor: 0.55 },
+              { type: "endurance", minutes: 40, factor: 0.65 },
+              { type: "cooldown", minutes: 5, factor: 0.5 },
+            ],
+            interval: [
+              { type: "warmup", minutes: 10, factor: 0.55 },
+              {
+                type: "interval",
+                minutes: 4,
+                factor: 1.05,
+                repeats: 5,
+                rest: 3,
+                restFactor: 0.55,
+              },
+              { type: "cooldown", minutes: 5, factor: 0.5 },
+            ],
+          },
+          intermediate: {
+            endurance: [
+              { type: "warmup", minutes: 10, factor: 0.6 },
+              { type: "endurance", minutes: 50, factor: 0.7 },
+              { type: "cooldown", minutes: 5, factor: 0.5 },
+            ],
+            interval: [
+              { type: "warmup", minutes: 10, factor: 0.6 },
+              {
+                type: "interval",
+                minutes: 5,
+                factor: 1.05,
+                repeats: 6,
+                rest: 3,
+                restFactor: 0.6,
+              },
+              { type: "cooldown", minutes: 5, factor: 0.5 },
+            ],
+          },
+          advanced: {
+            endurance: [
+              { type: "warmup", minutes: 10, factor: 0.65 },
+              { type: "endurance", minutes: 60, factor: 0.75 },
+              { type: "cooldown", minutes: 5, factor: 0.5 },
+            ],
+            interval: [
+              { type: "warmup", minutes: 10, factor: 0.65 },
+              {
+                type: "interval",
+                minutes: 6,
+                factor: 1.1,
+                repeats: 6,
+                rest: 3,
+                restFactor: 0.6,
+              },
+              { type: "cooldown", minutes: 5, factor: 0.5 },
+            ],
+          },
+        };
+
+        const sessionMinutes = Math.round((hours * 60) / days);
+        const hiSessions = Math.max(1, Math.round(days * 0.2));
+        const schema = [];
+
+        for (let week = 1; week <= 6; week++) {
+          for (let d = 1; d <= days; d++) {
+            const highIntensity = d <= hiSessions;
+            const type = highIntensity ? "interval" : "endurance";
+            const base = plans[level][type];
+            const blocks = scaleBlocks(base, sessionMinutes);
+            schema.push({
+              day: `Week ${week} - Dag ${d}`,
+              title: highIntensity ? "Intensieve training" : "Duurtraining",
+              blocks,
+            });
+          }
+        }
+
+        return schema;
+      }
+
+      function generateTcxWorkout(title, blocks, ftp) {
+        const steps = [];
+
+        blocks.forEach((block) => {
+          if (block.type === "interval") {
+            for (let i = 0; i < block.repeats; i++) {
+              steps.push({
+                name: `Interval ${i + 1}`,
+                duration: block.minutes * 60,
+                power: Math.round(ftp * block.factor),
+              });
+              steps.push({
+                name: `Rust ${i + 1}`,
+                duration: block.rest * 60,
+                power: Math.round(ftp * block.restFactor),
+              });
+            }
+          } else {
+            steps.push({
+              name: block.type.charAt(0).toUpperCase() + block.type.slice(1),
+              duration: block.minutes * 60,
+              power: Math.round(ftp * block.factor),
+            });
+          }
+        });
+
+        const xmlSteps = steps
+          .map(
+            (s) => `
+      <Step>
+        <Name>${s.name}</Name>
+        <Duration>
+          <DurationType>Time</DurationType>
+          <Seconds>${s.duration}</Seconds>
+        </Duration>
+        <Target>
+          <TargetType>Power</TargetType>
+          <PowerZone>${s.power}</PowerZone>
+        </Target>
+      </Step>`
+          )
+          .join("");
+
+        return `<?xml version="1.0" encoding="UTF-8"?>
+<TrainingCenterDatabase xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2">
+  <Workouts>
+    <Workout Sport="Biking">
+      <Name>${title}</Name>
+      ${xmlSteps}
+    </Workout>
+  </Workouts>
+</TrainingCenterDatabase>`;
+      }
+
+      function downloadTcx(title, blocks, ftp) {
+        const xml = generateTcxWorkout(title, blocks, ftp);
+        const blob = new Blob([xml], { type: "application/xml" });
+        const link = document.createElement("a");
+        link.href = URL.createObjectURL(blob);
+        link.download = `${title.replace(/\s+/g, "_")}.tcx`;
+        link.click();
+      }
+
+      function SchemaView({ intake, onUpdateFtp }) {
+        const schema = generateSchema(intake);
+
+        return (
+          <div className="min-h-screen bg-gray-100 p-6">
+            <div className="max-w-3xl mx-auto bg-white shadow rounded-lg p-6 space-y-6">
+              <h1 className="text-3xl font-bold text-gray-800">Trainingsschema</h1>
+              <p className="text-gray-600">
+                Niveau: <strong>{intake.level}</strong> · Dagen/week: <strong>{intake.days}</strong> · Uren/week: <strong>{intake.hours}</strong> · FTP: <strong>{intake.ftp} watt</strong>
+              </p>
+
+              <div className="grid gap-4">
+                {schema.map((item, index) => (
+                  <div key={index} className="bg-blue-50 p-4 rounded shadow-sm border border-blue-200">
+                    <h2 className="text-xl font-semibold text-blue-800">{item.day}</h2>
+                    <p className="text-gray-700 mb-2">
+                      Trainingsvorm: <strong>{item.title}</strong>
+                    </p>
+                    <ul className="list-disc ml-5 text-gray-600">
+                      {item.blocks.map((b, i) => (
+                        <li key={i}>
+                          {b.type === "interval"
+                            ? `${b.repeats}x ${b.minutes} min @ ${Math.round(
+                                intake.ftp * b.factor
+                              )} watt + ${b.rest} min rust @ ${Math.round(
+                                intake.ftp * b.restFactor
+                              )} watt`
+                            : `${b.minutes} min @ ${Math.round(
+                                intake.ftp * b.factor
+                              )} watt (${b.type})`}
+                        </li>
+                      ))}
+                    </ul>
+                    <button
+                      onClick={() => downloadTcx(item.title, item.blocks, intake.ftp)}
+                      className="mt-3 inline-block bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+                    >
+                      Download .TCX
+                    </button>
+                  </div>
+                ))}
+              </div>
+
+              <div className="pt-4">
+                <label className="block text-gray-700 font-medium mb-1">Update je FTP:</label>
+                <input
+                  type="number"
+                  className="w-full border border-gray-300 p-2 rounded"
+                  placeholder="Nieuwe FTP"
+                  onChange={(e) => onUpdateFtp(parseInt(e.target.value))}
+                />
+              </div>
+            </div>
+          </div>
+        );
+      }
+
+      function App() {
+        const [intake, setIntake] = useState(null);
+
+        const handleUpdateFtp = (newFtp) => {
+          setIntake((prev) => ({ ...prev, ftp: newFtp }));
+        };
+
+        return intake ? (
+          <SchemaView intake={intake} onUpdateFtp={handleUpdateFtp} />
+        ) : (
+          <TrainingIntake onComplete={setIntake} />
+        );
+      }
+
+      ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+    </script>
   </body>
 </html>

--- a/src/TrainingIntake.jsx
+++ b/src/TrainingIntake.jsx
@@ -4,11 +4,24 @@ export default function TrainingIntake({ onComplete }) {
   const [level, setLevel] = useState('beginner');
   const [days, setDays] = useState(3);
   const [ftp, setFtp] = useState('');
+  const [hours, setHours] = useState('');
+  const [email, setEmail] = useState('');
 
   const handleSubmit = (e) => {
     e.preventDefault();
     const parsedFtp = parseInt(ftp);
-    onComplete({ level, days, ftp: isNaN(parsedFtp) ? 200 : parsedFtp });
+    const parsedHours = parseFloat(hours);
+    if (!email) {
+      alert('E-mailadres is verplicht');
+      return;
+    }
+    onComplete({
+      level,
+      days,
+      hours: isNaN(parsedHours) ? 5 : parsedHours,
+      ftp: isNaN(parsedFtp) ? 200 : parsedFtp,
+      email,
+    });
   };
 
   return (
@@ -51,6 +64,29 @@ export default function TrainingIntake({ onComplete }) {
             value={ftp}
             onChange={(e) => setFtp(e.target.value)}
             className="w-full border border-gray-300 p-2 rounded"
+          />
+        </div>
+
+        <div>
+          <label className="block text-gray-600 mb-1">Uren beschikbaar per week:</label>
+          <input
+            type="number"
+            value={hours}
+            onChange={(e) => setHours(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded"
+            min="1"
+            step="0.5"
+          />
+        </div>
+
+        <div>
+          <label className="block text-gray-600 mb-1">E-mailadres:</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded"
+            required
           />
         </div>
 


### PR DESCRIPTION
## Summary
- embed React, ReactDOM, Babel and Tailwind via CDN so the app works without building
- inline all React components directly in `index.html`
- allow generating a 6‑week cycling plan after filling the form

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*
