### PR TITLE
Add weekly TSS and varied workouts

### DIFF
--- a/src/SchemaView.jsx
+++ b/src/SchemaView.jsx
@@ -1,32 +1,156 @@
-function generateSchema({ level, days, ftp }) {
-  const planByLevel = {
-    beginner: [
-      { type: 'warmup', minutes: 10, factor: 0.55 },
-      { type: 'endurance', minutes: 30, factor: 0.65 },
-      { type: 'cooldown', minutes: 5, factor: 0.5 },
-    ],
-    intermediate: [
-      { type: 'warmup', minutes: 10, factor: 0.6 },
-      { type: 'interval', minutes: 5, factor: 1.05, repeats: 4, rest: 3, restFactor: 0.6 },
-      { type: 'cooldown', minutes: 5, factor: 0.5 },
-    ],
-    advanced: [
-      { type: 'warmup', minutes: 10, factor: 0.65 },
-      { type: 'interval', minutes: 6, factor: 1.1, repeats: 5, rest: 3, restFactor: 0.6 },
-      { type: 'cooldown', minutes: 5, factor: 0.5 },
-    ],
+function totalMinutes(blocks) {
+  return blocks.reduce((sum, b) => {
+    if (b.type === 'interval') {
+      return sum + b.repeats * (b.minutes + b.rest);
+    }
+    return sum + b.minutes;
+  }, 0);
+}
+
+function computeTss(blocks) {
+  const score = blocks.reduce((sum, b) => {
+    if (b.type === 'interval') {
+      const work = b.repeats * b.minutes * Math.pow(b.factor, 2);
+      const rest = b.repeats * b.rest * Math.pow(b.restFactor || 0.55, 2);
+      return sum + work + rest;
+    }
+    return sum + b.minutes * Math.pow(b.factor, 2);
+  }, 0);
+  return Math.round((score / 60) * 100);
+}
+
+function scaleBlocks(blocks, target) {
+  const base = totalMinutes(blocks);
+  const ratio = target / base;
+  return blocks.map((b) => {
+    const scaled = { ...b };
+    scaled.minutes = Math.round(b.minutes * ratio);
+    if (b.rest) scaled.rest = Math.round(b.rest * ratio);
+    return scaled;
+  });
+}
+
+function generateSchema({ level, days, ftp, hours }) {
+  const plans = {
+    beginner: {
+      endurance: [
+        { type: 'warmup', minutes: 10, factor: 0.55 },
+        { type: 'endurance', minutes: 40, factor: 0.65 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      tempo: [
+        { type: 'warmup', minutes: 10, factor: 0.6 },
+        { type: 'tempo', minutes: 20, factor: 0.8 },
+        { type: 'endurance', minutes: 10, factor: 0.7 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      steigerung: [
+        { type: 'warmup', minutes: 10, factor: 0.55 },
+        { type: 'interval', minutes: 5, factor: 0.85, repeats: 1, rest: 1, restFactor: 0.6 },
+        { type: 'interval', minutes: 5, factor: 0.95, repeats: 1, rest: 1, restFactor: 0.6 },
+        { type: 'interval', minutes: 5, factor: 1.05, repeats: 1, rest: 1, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      vo2max: [
+        { type: 'warmup', minutes: 10, factor: 0.6 },
+        { type: 'interval', minutes: 3, factor: 1.15, repeats: 5, rest: 3, restFactor: 0.55 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      interval: [
+        { type: 'warmup', minutes: 10, factor: 0.55 },
+        { type: 'interval', minutes: 4, factor: 1.05, repeats: 5, rest: 3, restFactor: 0.55 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+    },
+    intermediate: {
+      endurance: [
+        { type: 'warmup', minutes: 10, factor: 0.6 },
+        { type: 'endurance', minutes: 50, factor: 0.7 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      tempo: [
+        { type: 'warmup', minutes: 10, factor: 0.65 },
+        { type: 'tempo', minutes: 30, factor: 0.82 },
+        { type: 'endurance', minutes: 10, factor: 0.7 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      steigerung: [
+        { type: 'warmup', minutes: 10, factor: 0.6 },
+        { type: 'interval', minutes: 6, factor: 0.9, repeats: 1, rest: 1, restFactor: 0.6 },
+        { type: 'interval', minutes: 6, factor: 1.0, repeats: 1, rest: 1, restFactor: 0.6 },
+        { type: 'interval', minutes: 6, factor: 1.1, repeats: 1, rest: 1, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      vo2max: [
+        { type: 'warmup', minutes: 10, factor: 0.65 },
+        { type: 'interval', minutes: 3, factor: 1.2, repeats: 6, rest: 3, restFactor: 0.55 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      interval: [
+        { type: 'warmup', minutes: 10, factor: 0.6 },
+        { type: 'interval', minutes: 5, factor: 1.05, repeats: 6, rest: 3, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+    },
+    advanced: {
+      endurance: [
+        { type: 'warmup', minutes: 10, factor: 0.65 },
+        { type: 'endurance', minutes: 60, factor: 0.75 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      tempo: [
+        { type: 'warmup', minutes: 10, factor: 0.7 },
+        { type: 'tempo', minutes: 40, factor: 0.85 },
+        { type: 'endurance', minutes: 10, factor: 0.75 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      steigerung: [
+        { type: 'warmup', minutes: 10, factor: 0.65 },
+        { type: 'interval', minutes: 7, factor: 1.0, repeats: 1, rest: 1, restFactor: 0.6 },
+        { type: 'interval', minutes: 7, factor: 1.1, repeats: 1, rest: 1, restFactor: 0.6 },
+        { type: 'interval', minutes: 7, factor: 1.2, repeats: 1, rest: 1, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      vo2max: [
+        { type: 'warmup', minutes: 10, factor: 0.7 },
+        { type: 'interval', minutes: 3, factor: 1.3, repeats: 7, rest: 3, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      interval: [
+        { type: 'warmup', minutes: 10, factor: 0.65 },
+        { type: 'interval', minutes: 6, factor: 1.1, repeats: 6, rest: 3, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+    },
   };
 
-  const schema = [];
-  for (let i = 0; i < days; i++) {
-    const baseBlocks = planByLevel[level];
-    schema.push({
-      day: `Dag ${i + 1}`,
-      title: `Trainingsblok ${i + 1}`,
-      blocks: baseBlocks,
-    });
+  const sessionMinutes = Math.round((hours * 60) / days);
+  const hiSessions = Math.max(1, Math.round(days * 0.3));
+  const hiTypes = ['vo2max', 'interval', 'steigerung', 'tempo'];
+  const weeks = [];
+
+  for (let week = 1; week <= 6; week++) {
+    const workouts = [];
+    for (let d = 1; d <= days; d++) {
+      const highIntensity = d <= hiSessions;
+      const type = highIntensity
+        ? hiTypes[(week + d) % hiTypes.length]
+        : 'endurance';
+      const base = plans[level][type];
+      const blocks = scaleBlocks(base, sessionMinutes);
+      const tss = computeTss(blocks);
+      workouts.push({
+        day: `Dag ${d}`,
+        title: type.charAt(0).toUpperCase() + type.slice(1),
+        blocks,
+        tss,
+      });
+    }
+    const weekTss = workouts.reduce((sum, w) => sum + w.tss, 0);
+    weeks.push({ week: `Week ${week}`, workouts, tss: weekTss });
   }
-  return schema;
+
+  return weeks;
 }
 
 function generateTcxWorkout(title, blocks, ftp) {
@@ -91,36 +215,48 @@ function downloadTcx(title, blocks, ftp) {
 }
 
 export default function SchemaView({ intake, onUpdateFtp }) {
-  const schema = generateSchema(intake);
+  const weeks = generateSchema(intake);
 
   return (
-    <div className="min-h-screen bg-gray-100 p-6">
-      <div className="max-w-3xl mx-auto bg-white shadow rounded-lg p-6 space-y-6">
-        <h1 className="text-3xl font-bold text-gray-800">Trainingsschema</h1>
-        <p className="text-gray-600">
-          Niveau: <strong>{intake.level}</strong> · Dagen/week: <strong>{intake.days}</strong> · FTP: <strong>{intake.ftp} watt</strong>
+    <div className="min-h-screen bg-gradient-to-b from-purple-700 via-purple-900 to-black p-6 text-white">
+      <div className="max-w-4xl mx-auto bg-white bg-opacity-90 shadow rounded-lg p-6 space-y-6 text-gray-800">
+        <h1 className="text-3xl font-bold text-center text-purple-700">Trainingsschema</h1>
+        <p className="text-center text-gray-700">
+          Niveau: <strong>{intake.level}</strong> · Dagen/week: <strong>{intake.days}</strong> · Uren/week: <strong>{intake.hours}</strong> · FTP: <strong>{intake.ftp} watt</strong>
         </p>
 
-        <div className="grid gap-4">
-          {schema.map((item, index) => (
-            <div key={index} className="bg-blue-50 p-4 rounded shadow-sm border border-blue-200">
-              <h2 className="text-xl font-semibold text-blue-800">{item.day}</h2>
-              <p className="text-gray-700 mb-2">Trainingsvorm: <strong>{item.title}</strong></p>
-              <ul className="list-disc ml-5 text-gray-600">
-                {item.blocks.map((b, i) => (
-                  <li key={i}>
-                    {b.type === 'interval'
-                      ? `${b.repeats}x ${b.minutes} min @ ${Math.round(intake.ftp * b.factor)} watt + ${b.rest} min rust @ ${Math.round(intake.ftp * b.restFactor)} watt`
-                      : `${b.minutes} min @ ${Math.round(intake.ftp * b.factor)} watt (${b.type})`}
-                  </li>
+        <div className="space-y-6">
+          {weeks.map((week, wIndex) => (
+            <div key={wIndex} className="border rounded p-4 bg-purple-50">
+              <h2 className="text-xl font-semibold text-purple-800 flex justify-between">
+                <span>{week.week}</span>
+                <span>TSS: {week.tss}</span>
+              </h2>
+              <div className="grid gap-4 mt-2">
+                {week.workouts.map((item, index) => (
+                  <div key={index} className="bg-white p-4 rounded shadow-sm border border-purple-200">
+                    <h3 className="text-lg font-medium text-purple-800 flex justify-between">
+                      <span>{item.day}: {item.title}</span>
+                      <span>TSS {item.tss}</span>
+                    </h3>
+                    <ul className="list-disc ml-5 text-gray-600">
+                      {item.blocks.map((b, i) => (
+                        <li key={i}>
+                          {b.type === 'interval'
+                            ? `${b.repeats}x ${b.minutes} min @ ${Math.round(intake.ftp * b.factor)} watt + ${b.rest} min rust @ ${Math.round(intake.ftp * b.restFactor)} watt`
+                            : `${b.minutes} min @ ${Math.round(intake.ftp * b.factor)} watt (${b.type})`}
+                        </li>
+                      ))}
+                    </ul>
+                    <button
+                      onClick={() => downloadTcx(item.title, item.blocks, intake.ftp)}
+                      className="mt-3 inline-block bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+                    >
+                      Download .TCX
+                    </button>
+                  </div>
                 ))}
-              </ul>
-              <button
-                onClick={() => downloadTcx(item.title, item.blocks, intake.ftp)}
-                className="mt-3 inline-block bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
-              >
-                Download .TCX
-              </button>
+              </div>
             </div>
           ))}
         </div>

--- a/src/TrainingIntake.jsx
+++ b/src/TrainingIntake.jsx
@@ -4,20 +4,36 @@ export default function TrainingIntake({ onComplete }) {
   const [level, setLevel] = useState('beginner');
   const [days, setDays] = useState(3);
   const [ftp, setFtp] = useState('');
+  const [hours, setHours] = useState('');
+  const [email, setEmail] = useState('');
 
   const handleSubmit = (e) => {
     e.preventDefault();
     const parsedFtp = parseInt(ftp);
-    onComplete({ level, days, ftp: isNaN(parsedFtp) ? 200 : parsedFtp });
+    const parsedHours = parseFloat(hours);
+    if (!email) {
+      alert('E-mailadres is verplicht');
+      return;
+    }
+    onComplete({
+      level,
+      days,
+      hours: isNaN(parsedHours) ? 5 : parsedHours,
+      ftp: isNaN(parsedFtp) ? 200 : parsedFtp,
+      email,
+    });
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-purple-700 via-purple-900 to-black text-white">
       <form
         onSubmit={handleSubmit}
-        className="bg-white p-8 rounded shadow-md w-full max-w-md space-y-6"
+        className="bg-white bg-opacity-90 p-8 rounded shadow-md w-full max-w-md space-y-6 text-gray-800"
       >
-        <h2 className="text-2xl font-bold text-center text-gray-700">Trainingsintake</h2>
+        <h1 className="text-3xl font-bold text-center text-purple-700">Gratis 6 Weken Trainingsschema</h1>
+        <p className="text-center text-sm text-gray-600">
+          Vul je gegevens in en ontvang een gepolariseerd schema afgestemd op jouw FTP en beschikbare tijd.
+        </p>
 
         <div>
           <label className="block text-gray-600 mb-1">Niveau:</label>
@@ -54,9 +70,32 @@ export default function TrainingIntake({ onComplete }) {
           />
         </div>
 
+        <div>
+          <label className="block text-gray-600 mb-1">Uren beschikbaar per week:</label>
+          <input
+            type="number"
+            value={hours}
+            onChange={(e) => setHours(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded"
+            min="1"
+            step="0.5"
+          />
+        </div>
+
+        <div>
+          <label className="block text-gray-600 mb-1">E-mailadres:</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded"
+            required
+          />
+        </div>
+
         <button
           type="submit"
-          className="w-full bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600"
+          className="w-full bg-purple-700 text-white py-2 px-4 rounded hover:bg-purple-800"
         >
           Genereer Schema
         </button>


### PR DESCRIPTION
## Summary
- overhaul TrainingIntake heading with purple gradient styling
- introduce computeTss and new workout templates (tempo, steigerung, vo2max)
- generate polarized 6-week plan with weekly TSS summary
- style weeks in purple and show per-workout TSS

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*