### PR TITLE
Add multi-step intake and TSS

### DIFF
--- a/src/SchemaView.jsx
+++ b/src/SchemaView.jsx
@@ -1,31 +1,94 @@
-function generateSchema({ level, days, ftp }) {
-  const planByLevel = {
-    beginner: [
-      { type: 'warmup', minutes: 10, factor: 0.55 },
-      { type: 'endurance', minutes: 30, factor: 0.65 },
-      { type: 'cooldown', minutes: 5, factor: 0.5 },
-    ],
-    intermediate: [
-      { type: 'warmup', minutes: 10, factor: 0.6 },
-      { type: 'interval', minutes: 5, factor: 1.05, repeats: 4, rest: 3, restFactor: 0.6 },
-      { type: 'cooldown', minutes: 5, factor: 0.5 },
-    ],
-    advanced: [
-      { type: 'warmup', minutes: 10, factor: 0.65 },
-      { type: 'interval', minutes: 6, factor: 1.1, repeats: 5, rest: 3, restFactor: 0.6 },
-      { type: 'cooldown', minutes: 5, factor: 0.5 },
-    ],
+function totalMinutes(blocks) {
+  return blocks.reduce((sum, b) => {
+    if (b.type === 'interval') {
+      return sum + b.repeats * (b.minutes + b.rest);
+    }
+    return sum + b.minutes;
+  }, 0);
+}
+
+function scaleBlocks(blocks, target) {
+  const base = totalMinutes(blocks);
+  const ratio = target / base;
+  return blocks.map((b) => {
+    const scaled = { ...b };
+    scaled.minutes = Math.round(b.minutes * ratio);
+    if (b.rest) scaled.rest = Math.round(b.rest * ratio);
+    return scaled;
+  });
+}
+
+function computeTss(blocks) {
+  let weighted = 0;
+  blocks.forEach((b) => {
+    if (b.type === 'interval') {
+      for (let i = 0; i < b.repeats; i++) {
+        weighted += b.minutes * 60 * Math.pow(b.factor, 2);
+        weighted += b.rest * 60 * Math.pow(b.restFactor, 2);
+      }
+    } else {
+      weighted += b.minutes * 60 * Math.pow(b.factor, 2);
+    }
+  });
+  return Math.round(weighted / 36);
+}
+
+function generateSchema({ level, days, ftp, hours }) {
+  const plans = {
+    beginner: {
+      endurance: [
+        { type: 'warmup', minutes: 10, factor: 0.55 },
+        { type: 'endurance', minutes: 40, factor: 0.65 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      interval: [
+        { type: 'warmup', minutes: 10, factor: 0.55 },
+        { type: 'interval', minutes: 4, factor: 1.05, repeats: 5, rest: 3, restFactor: 0.55 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      vo2max: [
+        { type: 'warmup', minutes: 10, factor: 0.55 },
+        { type: 'interval', minutes: 3, factor: 1.2, repeats: 5, rest: 3, restFactor: 0.55 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      tempo: [
+        { type: 'warmup', minutes: 10, factor: 0.55 },
+        { type: 'tempo', minutes: 30, factor: 0.85 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      steigerung: [
+        { type: 'warmup', minutes: 10, factor: 0.55 },
+        { type: 'endurance', minutes: 15, factor: 0.7 },
+        { type: 'tempo', minutes: 10, factor: 0.9 },
+        { type: 'interval', minutes: 2, factor: 1.1, repeats: 3, rest: 2, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+    },
   };
 
+  const sessionMinutes = Math.round((hours * 60) / days);
+  const hiSessions = Math.max(1, Math.round(days * 0.2));
+  const hiTypes = ['interval', 'vo2max', 'steigerung', 'tempo'];
   const schema = [];
-  for (let i = 0; i < days; i++) {
-    const baseBlocks = planByLevel[level];
-    schema.push({
-      day: `Dag ${i + 1}`,
-      title: `Trainingsblok ${i + 1}`,
-      blocks: baseBlocks,
-    });
+
+  for (let week = 1; week <= 6; week++) {
+    for (let d = 1; d <= days; d++) {
+      const hiIndex = (week * d) % hiTypes.length;
+      const highIntensity = d <= hiSessions;
+      const type = highIntensity ? hiTypes[hiIndex] : 'endurance';
+      const base = plans[level][type];
+      const blocks = scaleBlocks(base, sessionMinutes);
+      const tss = computeTss(blocks);
+      schema.push({
+        day: `Week ${week} - Dag ${d}`,
+        week,
+        title: highIntensity ? type : 'duurtraining',
+        blocks,
+        tss,
+      });
+    }
   }
+
   return schema;
 }
 
@@ -92,38 +155,51 @@ function downloadTcx(title, blocks, ftp) {
 
 export default function SchemaView({ intake, onUpdateFtp }) {
   const schema = generateSchema(intake);
+  const weeks = {};
+  schema.forEach((s) => {
+    if (!weeks[s.week]) {
+      weeks[s.week] = { tss: 0, sessions: [] };
+    }
+    weeks[s.week].tss += s.tss;
+    weeks[s.week].sessions.push(s);
+  });
 
   return (
     <div className="min-h-screen bg-gray-100 p-6">
-      <div className="max-w-3xl mx-auto bg-white shadow rounded-lg p-6 space-y-6">
+      <div className="max-w-3xl mx-auto bg-white shadow rounded-lg p-6 space-y-8">
         <h1 className="text-3xl font-bold text-gray-800">Trainingsschema</h1>
         <p className="text-gray-600">
-          Niveau: <strong>{intake.level}</strong> · Dagen/week: <strong>{intake.days}</strong> · FTP: <strong>{intake.ftp} watt</strong>
+          Uren/week: <strong>{intake.hours}</strong> · FTP: <strong>{intake.ftp} watt</strong>
         </p>
 
-        <div className="grid gap-4">
-          {schema.map((item, index) => (
-            <div key={index} className="bg-blue-50 p-4 rounded shadow-sm border border-blue-200">
-              <h2 className="text-xl font-semibold text-blue-800">{item.day}</h2>
-              <p className="text-gray-700 mb-2">Trainingsvorm: <strong>{item.title}</strong></p>
-              <ul className="list-disc ml-5 text-gray-600">
-                {item.blocks.map((b, i) => (
-                  <li key={i}>
-                    {b.type === 'interval'
-                      ? `${b.repeats}x ${b.minutes} min @ ${Math.round(intake.ftp * b.factor)} watt + ${b.rest} min rust @ ${Math.round(intake.ftp * b.restFactor)} watt`
-                      : `${b.minutes} min @ ${Math.round(intake.ftp * b.factor)} watt (${b.type})`}
-                  </li>
-                ))}
-              </ul>
-              <button
-                onClick={() => downloadTcx(item.title, item.blocks, intake.ftp)}
-                className="mt-3 inline-block bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
-              >
-                Download .TCX
-              </button>
+        {Object.entries(weeks).map(([week, data]) => (
+          <div key={week} className="space-y-4">
+            <h2 className="text-2xl font-bold text-purple-700">Week {week} - totaal TSS: {Math.round(data.tss)}</h2>
+            <div className="grid gap-4">
+              {data.sessions.map((item, index) => (
+                <div key={index} className="bg-blue-50 p-4 rounded shadow-sm border border-blue-200">
+                  <h3 className="text-xl font-semibold text-blue-800">{item.day}</h3>
+                  <p className="text-gray-700 mb-2">Trainingsvorm: <strong>{item.title}</strong> · TSS: {item.tss}</p>
+                  <ul className="list-disc ml-5 text-gray-600">
+                    {item.blocks.map((b, i) => (
+                      <li key={i}>
+                        {b.type === 'interval'
+                          ? `${b.repeats}x ${b.minutes} min @ ${Math.round(intake.ftp * b.factor)} watt + ${b.rest} min rust @ ${Math.round(intake.ftp * b.restFactor)} watt`
+                          : `${b.minutes} min @ ${Math.round(intake.ftp * b.factor)} watt (${b.type})`}
+                      </li>
+                    ))}
+                  </ul>
+                  <button
+                    onClick={() => downloadTcx(item.title, item.blocks, intake.ftp)}
+                    className="mt-3 inline-block bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+                  >
+                    Download .TCX
+                  </button>
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
+          </div>
+        ))}
 
         <div className="pt-4">
           <label className="block text-gray-700 font-medium mb-1">Update je FTP:</label>

--- a/src/TrainingIntake.jsx
+++ b/src/TrainingIntake.jsx
@@ -1,66 +1,90 @@
 import React, { useState } from 'react';
 
 export default function TrainingIntake({ onComplete }) {
-  const [level, setLevel] = useState('beginner');
-  const [days, setDays] = useState(3);
+  const [step, setStep] = useState(1);
   const [ftp, setFtp] = useState('');
+  const [hours, setHours] = useState('');
+  const [email, setEmail] = useState('');
+
+  const handleEmail = (e) => {
+    e.preventDefault();
+    if (!email) {
+      alert('E-mailadres is verplicht');
+      return;
+    }
+    setStep(2);
+  };
 
   const handleSubmit = (e) => {
     e.preventDefault();
     const parsedFtp = parseInt(ftp);
-    onComplete({ level, days, ftp: isNaN(parsedFtp) ? 200 : parsedFtp });
+    const parsedHours = parseFloat(hours);
+    if (isNaN(parsedFtp) || isNaN(parsedHours)) {
+      alert('Vul alstublieft alle velden in');
+      return;
+    }
+    onComplete({
+      email,
+      ftp: parsedFtp,
+      hours: parsedHours,
+      level: 'beginner',
+      days: 3,
+    });
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
-      <form
-        onSubmit={handleSubmit}
-        className="bg-white p-8 rounded shadow-md w-full max-w-md space-y-6"
-      >
-        <h2 className="text-2xl font-bold text-center text-gray-700">Trainingsintake</h2>
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-purple-800 to-black p-4">
+      {step === 1 && (
+        <form onSubmit={handleEmail} className="bg-white p-8 rounded shadow-md w-full max-w-md space-y-6">
+          <h1 className="text-3xl font-bold text-center text-gray-800">Gratis 6 Weken Trainingsschema</h1>
+          <p className="text-center text-gray-600">Ontvang direct toegang tot het schema.</p>
 
-        <div>
-          <label className="block text-gray-600 mb-1">Niveau:</label>
-          <select
-            value={level}
-            onChange={(e) => setLevel(e.target.value)}
-            className="w-full border border-gray-300 p-2 rounded"
-          >
-            <option value="beginner">Beginner</option>
-            <option value="intermediate">Gevorderd</option>
-            <option value="advanced">Expert</option>
-          </select>
-        </div>
+          <div>
+            <label className="block text-gray-600 mb-1">E-mailadres:</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full border border-gray-300 p-2 rounded"
+              required
+            />
+          </div>
 
-        <div>
-          <label className="block text-gray-600 mb-1">Dagen per week:</label>
-          <input
-            type="number"
-            value={days}
-            onChange={(e) => setDays(Number(e.target.value))}
-            className="w-full border border-gray-300 p-2 rounded"
-            min="1"
-            max="7"
-          />
-        </div>
+          <button type="submit" className="w-full bg-purple-600 text-white py-2 rounded hover:bg-purple-700">Volgende</button>
+        </form>
+      )}
 
-        <div>
-          <label className="block text-gray-600 mb-1">FTP:</label>
-          <input
-            type="number"
-            value={ftp}
-            onChange={(e) => setFtp(e.target.value)}
-            className="w-full border border-gray-300 p-2 rounded"
-          />
-        </div>
+      {step === 2 && (
+        <form onSubmit={handleSubmit} className="bg-white p-8 rounded shadow-md w-full max-w-md space-y-6">
+          <h2 className="text-2xl font-bold text-center text-gray-800">Jouw Gegevens</h2>
 
-        <button
-          type="submit"
-          className="w-full bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600"
-        >
-          Genereer Schema
-        </button>
-      </form>
+          <div>
+            <label className="block text-gray-600 mb-1">FTP:</label>
+            <input
+              type="number"
+              value={ftp}
+              onChange={(e) => setFtp(e.target.value)}
+              className="w-full border border-gray-300 p-2 rounded"
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-gray-600 mb-1">Uren beschikbaar per week:</label>
+            <input
+              type="number"
+              value={hours}
+              onChange={(e) => setHours(e.target.value)}
+              className="w-full border border-gray-300 p-2 rounded"
+              min="1"
+              step="0.5"
+              required
+            />
+          </div>
+
+          <button type="submit" className="w-full bg-purple-600 text-white py-2 rounded hover:bg-purple-700">Genereer Schema</button>
+        </form>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- convert intake form to a two step flow: first email, then FTP and hours
- default to beginner plan with 3 days and show premium purple gradient
- generate varied workouts (interval, vo2max, steigerung, tempo, endurance)
- calculate TSS for each session and weekly totals
- allow TCX download for every workout

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*