### PR TITLE
Improve intake and standalone schedule generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/index.html
+++ b/index.html
@@ -1,13 +1,326 @@
-
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Wielren Schema App</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
   </head>
-  <body>
+  <body class="min-h-screen bg-gradient-to-br from-purple-800 to-black text-white">
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="text/babel">
+      const { useState, useMemo } = React;
+
+      function TrainingIntake({ onComplete }) {
+        const [step, setStep] = useState(1);
+        const [email, setEmail] = useState("");
+        const [level, setLevel] = useState("beginner");
+        const [days, setDays] = useState(3);
+        const [ftp, setFtp] = useState("");
+        const [hours, setHours] = useState("");
+
+        const submitEmail = (e) => {
+          e.preventDefault();
+          if (!email) {
+            alert("E-mailadres is verplicht");
+            return;
+          }
+          setStep(2);
+        };
+
+        const submitForm = (e) => {
+          e.preventDefault();
+          const data = {
+            email,
+            level,
+            days: parseInt(days),
+            ftp: ftp ? parseInt(ftp) : 200,
+            hours: hours ? parseFloat(hours) : 5,
+          };
+          onComplete(data);
+        };
+
+        return (
+          <div className="flex items-center justify-center min-h-screen">
+            {step === 1 ? (
+              <form onSubmit={submitEmail} className="bg-white text-gray-800 p-8 rounded shadow-md w-full max-w-md space-y-4">
+                <h1 className="text-2xl font-bold text-center text-purple-700">Gratis 6 Weken Trainingsschema</h1>
+                <p className="text-center text-sm">Laat je e-mailadres achter voor gratis toegang.</p>
+                <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} className="w-full border border-gray-300 p-2 rounded" placeholder="E-mailadres" required />
+                <button type="submit" className="w-full bg-purple-700 text-white py-2 rounded hover:bg-purple-800">Volgende</button>
+              </form>
+            ) : (
+              <form onSubmit={submitForm} className="bg-white text-gray-800 p-8 rounded shadow-md w-full max-w-md space-y-4">
+                <h1 className="text-2xl font-bold text-center text-purple-700">Gratis 6 Weken Trainingsschema</h1>
+                <p className="text-center text-sm">Vul je FTP en beschikbare tijd in.</p>
+                <div>
+                  <label className="block mb-1">Niveau</label>
+                  <select value={level} onChange={(e) => setLevel(e.target.value)} className="w-full border border-gray-300 p-2 rounded">
+                    <option value="beginner">Beginner</option>
+                    <option value="intermediate">Gevorderd</option>
+                    <option value="advanced">Expert</option>
+                  </select>
+                </div>
+                <div>
+                  <label className="block mb-1">Dagen per week</label>
+                  <input type="number" value={days} onChange={(e) => setDays(e.target.value)} min="1" max="7" className="w-full border border-gray-300 p-2 rounded" />
+                </div>
+                <div>
+                  <label className="block mb-1">FTP</label>
+                  <input type="number" value={ftp} onChange={(e) => setFtp(e.target.value)} className="w-full border border-gray-300 p-2 rounded" />
+                </div>
+                <div>
+                  <label className="block mb-1">Uren per week</label>
+                  <input type="number" value={hours} onChange={(e) => setHours(e.target.value)} step="0.5" min="1" className="w-full border border-gray-300 p-2 rounded" />
+                </div>
+                <button type="submit" className="w-full bg-purple-700 text-white py-2 rounded hover:bg-purple-800">Genereer schema</button>
+              </form>
+            )}
+          </div>
+        );
+      }
+
+      function totalMinutes(blocks) {
+        return blocks.reduce((sum, b) => {
+          if (b.type === 'interval') {
+            return sum + b.repeats * (b.minutes + b.rest);
+          }
+          return sum + b.minutes;
+        }, 0);
+      }
+
+      function scaleBlocks(blocks, target) {
+        const base = totalMinutes(blocks);
+        const ratio = target / base;
+        return blocks.map((b) => {
+          const scaled = { ...b };
+          scaled.minutes = Math.round(b.minutes * ratio);
+          if (b.rest) scaled.rest = Math.round(b.rest * ratio);
+          return scaled;
+        });
+      }
+
+      function computeTss(blocks) {
+        let tss = 0;
+        blocks.forEach((b) => {
+          if (b.type === 'interval') {
+            for (let i = 0; i < b.repeats; i++) {
+              tss += (b.minutes / 60) * Math.pow(b.factor, 2) * 100;
+              tss += (b.rest / 60) * Math.pow(b.restFactor, 2) * 100;
+            }
+          } else {
+            tss += (b.minutes / 60) * Math.pow(b.factor, 2) * 100;
+          }
+        });
+        return Math.round(tss);
+      }
+
+      function workoutTitle(type) {
+        switch (type) {
+          case 'interval':
+            return 'Intervaltraining';
+          case 'vo2max':
+            return 'VO2max sessie';
+          case 'steigerung':
+            return 'Steigerung';
+          case 'tempo':
+            return 'Tempotraining';
+          default:
+            return 'Duurtraining';
+        }
+      }
+
+      function generateSchema({ level, days, ftp, hours }) {
+        const plans = {
+          beginner: {
+            endurance: [
+              { type: 'warmup', minutes: 10, factor: 0.55 },
+              { type: 'endurance', minutes: 40, factor: 0.65 },
+              { type: 'cooldown', minutes: 5, factor: 0.5 },
+            ],
+            interval: [
+              { type: 'warmup', minutes: 10, factor: 0.6 },
+              { type: 'interval', minutes: 4, factor: 1.1, repeats: 5, rest: 3, restFactor: 0.6 },
+              { type: 'cooldown', minutes: 5, factor: 0.5 },
+            ],
+            vo2max: [
+              { type: 'warmup', minutes: 10, factor: 0.6 },
+              { type: 'interval', minutes: 2, factor: 1.2, repeats: 6, rest: 3, restFactor: 0.6 },
+              { type: 'cooldown', minutes: 5, factor: 0.5 },
+            ],
+            steigerung: [
+              { type: 'warmup', minutes: 10, factor: 0.55 },
+              { type: 'steigerung', minutes: 20, factor: 0.8 },
+              { type: 'cooldown', minutes: 5, factor: 0.5 },
+            ],
+            tempo: [
+              { type: 'warmup', minutes: 10, factor: 0.55 },
+              { type: 'tempo', minutes: 25, factor: 0.9 },
+              { type: 'cooldown', minutes: 5, factor: 0.5 },
+            ],
+          },
+          intermediate: {
+            endurance: [
+              { type: 'warmup', minutes: 10, factor: 0.6 },
+              { type: 'endurance', minutes: 50, factor: 0.7 },
+              { type: 'cooldown', minutes: 5, factor: 0.5 },
+            ],
+            interval: [
+              { type: 'warmup', minutes: 10, factor: 0.6 },
+              { type: 'interval', minutes: 5, factor: 1.15, repeats: 6, rest: 3, restFactor: 0.6 },
+              { type: 'cooldown', minutes: 5, factor: 0.5 },
+            ],
+            vo2max: [
+              { type: 'warmup', minutes: 10, factor: 0.6 },
+              { type: 'interval', minutes: 3, factor: 1.25, repeats: 6, rest: 3, restFactor: 0.6 },
+              { type: 'cooldown', minutes: 5, factor: 0.5 },
+            ],
+            steigerung: [
+              { type: 'warmup', minutes: 10, factor: 0.6 },
+              { type: 'steigerung', minutes: 25, factor: 0.85 },
+              { type: 'cooldown', minutes: 5, factor: 0.5 },
+            ],
+            tempo: [
+              { type: 'warmup', minutes: 10, factor: 0.6 },
+              { type: 'tempo', minutes: 30, factor: 0.9 },
+              { type: 'cooldown', minutes: 5, factor: 0.5 },
+            ],
+          },
+          advanced: {
+            endurance: [
+              { type: 'warmup', minutes: 10, factor: 0.65 },
+              { type: 'endurance', minutes: 60, factor: 0.75 },
+              { type: 'cooldown', minutes: 5, factor: 0.5 },
+            ],
+            interval: [
+              { type: 'warmup', minutes: 10, factor: 0.65 },
+              { type: 'interval', minutes: 6, factor: 1.2, repeats: 6, rest: 3, restFactor: 0.6 },
+              { type: 'cooldown', minutes: 5, factor: 0.5 },
+            ],
+            vo2max: [
+              { type: 'warmup', minutes: 10, factor: 0.65 },
+              { type: 'interval', minutes: 4, factor: 1.3, repeats: 6, rest: 3, restFactor: 0.6 },
+              { type: 'cooldown', minutes: 5, factor: 0.5 },
+            ],
+            steigerung: [
+              { type: 'warmup', minutes: 10, factor: 0.65 },
+              { type: 'steigerung', minutes: 30, factor: 0.9 },
+              { type: 'cooldown', minutes: 5, factor: 0.5 },
+            ],
+            tempo: [
+              { type: 'warmup', minutes: 10, factor: 0.65 },
+              { type: 'tempo', minutes: 35, factor: 0.95 },
+              { type: 'cooldown', minutes: 5, factor: 0.5 },
+            ],
+          },
+        };
+
+        const hiTypes = ['interval', 'vo2max', 'steigerung', 'tempo'];
+        const sessionMinutes = Math.round((hours * 60) / days);
+        const hiSessions = Math.max(1, Math.round(days * 0.2));
+        const weeks = [];
+        let hiIndex = 0;
+
+        for (let week = 1; week <= 6; week++) {
+          let weekTss = 0;
+          const sessions = [];
+          for (let d = 1; d <= days; d++) {
+            const highIntensity = d <= hiSessions;
+            const type = highIntensity ? hiTypes[hiIndex++ % hiTypes.length] : 'endurance';
+            const base = plans[level][type];
+            const blocks = scaleBlocks(base, sessionMinutes);
+            const tss = computeTss(blocks);
+            weekTss += tss;
+            sessions.push({
+              day: `Week ${week} - Dag ${d}`,
+              title: workoutTitle(type),
+              blocks,
+              tss,
+            });
+          }
+          weeks.push({ week, sessions, tss: Math.round(weekTss) });
+        }
+
+        return weeks;
+      }
+
+      function generateTcxWorkout(title, blocks, ftp) {
+        const steps = [];
+        blocks.forEach((block) => {
+          if (block.type === 'interval') {
+            for (let i = 0; i < block.repeats; i++) {
+              steps.push({ name: `Interval ${i + 1}`, duration: block.minutes * 60, power: Math.round(ftp * block.factor) });
+              steps.push({ name: `Rust ${i + 1}`, duration: block.rest * 60, power: Math.round(ftp * block.restFactor) });
+            }
+          } else {
+            steps.push({ name: block.type, duration: block.minutes * 60, power: Math.round(ftp * block.factor) });
+          }
+        });
+        const xmlSteps = steps.map((s) => `\n      <Step>\n        <Name>${s.name}</Name>\n        <Duration>\n          <DurationType>Time</DurationType>\n          <Seconds>${s.duration}</Seconds>\n        </Duration>\n        <Target>\n          <TargetType>Power</TargetType>\n          <PowerZone>${s.power}</PowerZone>\n        </Target>\n      </Step>`).join('');
+        return `<?xml version="1.0" encoding="UTF-8"?>\n<TrainingCenterDatabase xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2">\n  <Workouts>\n    <Workout Sport="Biking">\n      <Name>${title}</Name>${xmlSteps}\n    </Workout>\n  </Workouts>\n</TrainingCenterDatabase>`;
+      }
+
+      function downloadTcx(title, blocks, ftp) {
+        const xml = generateTcxWorkout(title, blocks, ftp);
+        const blob = new Blob([xml], { type: 'application/xml' });
+        const link = document.createElement('a');
+        link.href = URL.createObjectURL(blob);
+        link.download = `${title.replace(/\s+/g, '_')}.tcx`;
+        link.click();
+      }
+
+      function SchemaView({ intake }) {
+        const [ftp, setFtp] = useState(intake.ftp);
+        const weeks = useMemo(() => generateSchema({ ...intake, ftp }), [intake, ftp]);
+
+        return (
+          <div className="p-4">
+            <div className="max-w-3xl mx-auto space-y-6">
+              <h1 className="text-3xl font-bold text-center">Trainingsschema</h1>
+              <p className="text-center">Niveau: <strong>{intake.level}</strong> · Dagen/week: <strong>{intake.days}</strong> · Uren/week: <strong>{intake.hours}</strong> · FTP: <strong>{ftp} watt</strong></p>
+              {weeks.map((week) => (
+                <div key={week.week} className="bg-white/10 p-4 rounded">
+                  <h2 className="text-xl font-semibold mb-2">Week {week.week} – totale TSS {week.tss}</h2>
+                  {week.sessions.map((sess, i) => (
+                    <div key={i} className="mb-3 p-3 bg-white/20 rounded">
+                      <h3 className="font-semibold">{sess.day}: {sess.title}</h3>
+                      <ul className="list-disc ml-5 text-sm">
+                        {sess.blocks.map((b, j) => (
+                          <li key={j}>{{
+                            interval: `${b.repeats}x ${b.minutes}min @ ${Math.round(ftp * b.factor)}W + ${b.rest}min rust`,
+                            steigerung: `${b.minutes}min steigerend @ ${Math.round(ftp * b.factor)}W`,
+                            tempo: `${b.minutes}min @ ${Math.round(ftp * b.factor)}W tempo`,
+                            vo2max: `${b.repeats}x ${b.minutes}min @ ${Math.round(ftp * b.factor)}W + ${b.rest}min rust`,
+                            endurance: `${b.minutes}min @ ${Math.round(ftp * b.factor)}W`,
+                            warmup: `${b.minutes}min warming-up`,
+                            cooldown: `${b.minutes}min cooling-down`,
+                          }[b.type] || `${b.minutes}min @ ${Math.round(ftp * b.factor)}W`}</li>
+                        ))}
+                      </ul>
+                      <p className="mt-1 text-sm">TSS: {sess.tss}</p>
+                      <button onClick={() => downloadTcx(sess.title, sess.blocks, ftp)} className="mt-2 inline-block bg-green-600 text-white px-3 py-1 rounded hover:bg-green-700">Download .TCX</button>
+                    </div>
+                  ))}
+                </div>
+              ))}
+              <div>
+                <label className="block mb-1">Update FTP</label>
+                <input type="number" className="w-full p-2 rounded text-gray-800" value={ftp} onChange={(e) => setFtp(parseInt(e.target.value) || 0)} />
+              </div>
+            </div>
+          </div>
+        );
+      }
+
+      function App() {
+        const [intake, setIntake] = useState(null);
+        return intake ? <SchemaView intake={intake} /> : <TrainingIntake onComplete={setIntake} />;
+      }
+
+      ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+    </script>
   </body>
 </html>

--- a/src/TrainingIntake.jsx
+++ b/src/TrainingIntake.jsx
@@ -4,11 +4,24 @@ export default function TrainingIntake({ onComplete }) {
   const [level, setLevel] = useState('beginner');
   const [days, setDays] = useState(3);
   const [ftp, setFtp] = useState('');
+  const [hours, setHours] = useState('');
+  const [email, setEmail] = useState('');
 
   const handleSubmit = (e) => {
     e.preventDefault();
     const parsedFtp = parseInt(ftp);
-    onComplete({ level, days, ftp: isNaN(parsedFtp) ? 200 : parsedFtp });
+    const parsedHours = parseFloat(hours);
+    if (!email) {
+      alert('E-mailadres is verplicht');
+      return;
+    }
+    onComplete({
+      level,
+      days,
+      hours: isNaN(parsedHours) ? 5 : parsedHours,
+      ftp: isNaN(parsedFtp) ? 200 : parsedFtp,
+      email,
+    });
   };
 
   return (
@@ -51,6 +64,29 @@ export default function TrainingIntake({ onComplete }) {
             value={ftp}
             onChange={(e) => setFtp(e.target.value)}
             className="w-full border border-gray-300 p-2 rounded"
+          />
+        </div>
+
+        <div>
+          <label className="block text-gray-600 mb-1">Uren beschikbaar per week:</label>
+          <input
+            type="number"
+            value={hours}
+            onChange={(e) => setHours(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded"
+            min="1"
+            step="0.5"
+          />
+        </div>
+
+        <div>
+          <label className="block text-gray-600 mb-1">E-mailadres:</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded"
+            required
           />
         </div>
 


### PR DESCRIPTION
## Summary
- add `.gitignore`
- implement standalone `index.html` with CDN React and Tailwind
- introduce multi-step intake form asking email first
- generate six-week polarized schedule with varied workouts and TSS
- allow TCX download for each workout

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*
