### PR TITLE
Switch to standalone HTML with multi-step intake

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,252 @@
-
 <!DOCTYPE html>
-<html lang="en">
+<html lang="nl">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Wielren Schema App</title>
+    <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+    <script src="https://cdn.tailwindcss.com"></script>
   </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+  <body class="min-h-screen bg-gradient-to-b from-purple-800 via-purple-900 to-black text-white">
+    <div id="root" class="p-4"></div>
+    <script type="text/babel">
+      const { useState } = React;
+
+      function scaleBlocks(blocks, target) {
+        const base = blocks.reduce((sum, b) => {
+          if (b.type === 'interval') {
+            return sum + b.repeats * (b.minutes + b.rest);
+          }
+          return sum + b.minutes;
+        }, 0);
+        const ratio = target / base;
+        return blocks.map(b => {
+          const obj = { ...b };
+          obj.minutes = Math.round(b.minutes * ratio);
+          if (b.rest) obj.rest = Math.round(b.rest * ratio);
+          return obj;
+        });
+      }
+
+      function computeTss(blocks) {
+        let tss = 0;
+        blocks.forEach(b => {
+          if (b.type === 'interval') {
+            for (let i = 0; i < b.repeats; i++) {
+              tss += (b.minutes / 60) * Math.pow(b.factor, 2) * 100;
+              tss += (b.rest / 60) * Math.pow(b.restFactor, 2) * 100;
+            }
+          } else {
+            tss += (b.minutes / 60) * Math.pow(b.factor, 2) * 100;
+          }
+        });
+        return Math.round(tss);
+      }
+
+      const templates = {
+        endurance: [
+          { type: 'warmup', minutes: 10, factor: 0.55 },
+          { type: 'endurance', minutes: 40, factor: 0.65 },
+          { type: 'cooldown', minutes: 5, factor: 0.5 },
+        ],
+        tempo: [
+          { type: 'warmup', minutes: 10, factor: 0.6 },
+          { type: 'tempo', minutes: 20, factor: 0.85 },
+          { type: 'endurance', minutes: 20, factor: 0.7 },
+          { type: 'cooldown', minutes: 5, factor: 0.5 },
+        ],
+        steigerung: [
+          { type: 'warmup', minutes: 10, factor: 0.6 },
+          { type: 'interval', minutes: 5, factor: 0.9, repeats: 5, rest: 2, restFactor: 0.6 },
+          { type: 'cooldown', minutes: 5, factor: 0.5 },
+        ],
+        interval: [
+          { type: 'warmup', minutes: 10, factor: 0.6 },
+          { type: 'interval', minutes: 4, factor: 1.05, repeats: 5, rest: 3, restFactor: 0.55 },
+          { type: 'cooldown', minutes: 5, factor: 0.5 },
+        ],
+        vo2max: [
+          { type: 'warmup', minutes: 10, factor: 0.6 },
+          { type: 'interval', minutes: 3, factor: 1.2, repeats: 5, rest: 3, restFactor: 0.55 },
+          { type: 'cooldown', minutes: 5, factor: 0.5 },
+        ],
+      };
+
+      const levelMultiplier = { beginner: 1, intermediate: 1.05, advanced: 1.1 };
+      const hiTypes = ['interval', 'vo2max', 'steigerung', 'tempo'];
+
+      function generateSchema({ level, days, ftp, hours }) {
+        const sessionMinutes = Math.round((hours * 60) / days);
+        const hiSessions = Math.max(1, Math.round(days * 0.2));
+        const result = [];
+        let hiIndex = 0;
+
+        for (let week = 1; week <= 6; week++) {
+          let weekData = { week, workouts: [], tss: 0 };
+          for (let d = 1; d <= days; d++) {
+            const high = d <= hiSessions;
+            const type = high ? hiTypes[hiIndex++ % hiTypes.length] : 'endurance';
+            let blocks = templates[type].map(b => ({ ...b }));
+            blocks.forEach(b => {
+              b.factor *= levelMultiplier[level];
+              if (b.restFactor) b.restFactor *= levelMultiplier[level];
+            });
+            blocks = scaleBlocks(blocks, sessionMinutes);
+            const tss = computeTss(blocks);
+            weekData.workouts.push({
+              day: `Week ${week} - Dag ${d}`,
+              title: type.charAt(0).toUpperCase() + type.slice(1),
+              blocks,
+              tss,
+            });
+            weekData.tss += tss;
+          }
+          weekData.tss = Math.round(weekData.tss);
+          result.push(weekData);
+        }
+        return result;
+      }
+
+      function generateTcxWorkout(title, blocks, ftp) {
+        const steps = [];
+        blocks.forEach((block) => {
+          if (block.type === 'interval') {
+            for (let i = 0; i < block.repeats; i++) {
+              steps.push({ name: `Interval ${i + 1}`, duration: block.minutes * 60, power: Math.round(ftp * block.factor) });
+              steps.push({ name: `Rust ${i + 1}`, duration: block.rest * 60, power: Math.round(ftp * block.restFactor) });
+            }
+          } else {
+            steps.push({ name: block.type, duration: block.minutes * 60, power: Math.round(ftp * block.factor) });
+          }
+        });
+        const xmlSteps = steps.map((s) => `\n      <Step>\n        <Name>${s.name}</Name>\n        <Duration>\n          <DurationType>Time</DurationType>\n          <Seconds>${s.duration}</Seconds>\n        </Duration>\n        <Target>\n          <TargetType>Power</TargetType>\n          <PowerZone>${s.power}</PowerZone>\n        </Target>\n      </Step>`).join('');
+        return `<?xml version="1.0" encoding="UTF-8"?>\n<TrainingCenterDatabase xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2">\n  <Workouts>\n    <Workout Sport="Biking">\n      <Name>${title}</Name>${xmlSteps}\n    </Workout>\n  </Workouts>\n</TrainingCenterDatabase>`;
+      }
+
+      function downloadTcx(title, blocks, ftp) {
+        const xml = generateTcxWorkout(title, blocks, ftp);
+        const blob = new Blob([xml], { type: 'application/xml' });
+        const link = document.createElement('a');
+        link.href = URL.createObjectURL(blob);
+        link.download = `${title.replace(/\s+/g, '_')}.tcx`;
+        link.click();
+      }
+
+      function TrainingIntake({ onComplete }) {
+        const [step, setStep] = useState(1);
+        const [email, setEmail] = useState('');
+        const [ftp, setFtp] = useState('');
+        const [hours, setHours] = useState('');
+        const [days, setDays] = useState(3);
+        const [level, setLevel] = useState('beginner');
+        const [showInfo, setShowInfo] = useState(false);
+
+        const next = (e) => {
+          e.preventDefault();
+          if (!email) return alert('E-mailadres is verplicht');
+          setStep(2);
+        };
+
+        const submit = (e) => {
+          e.preventDefault();
+          const data = {
+            email,
+            ftp: parseInt(ftp) || 200,
+            hours: parseFloat(hours) || 5,
+            days: parseInt(days) || 3,
+            level,
+          };
+          onComplete(data);
+        };
+
+        return (
+          <div className="flex items-center justify-center min-h-screen">
+            <form onSubmit={step === 1 ? next : submit} className="bg-white/10 backdrop-blur-md p-6 rounded-lg space-y-4 w-full max-w-md">
+              <h1 className="text-2xl font-bold text-center">Gratis 6 Weken Trainingsschema</h1>
+              <p className="text-sm text-purple-200 text-center">Krijg een persoonlijk schema gebaseerd op je FTP en beschikbare tijd.</p>
+              {step === 1 && (
+                <div className="space-y-4">
+                  <div>
+                    <label className="block mb-1">E-mailadres</label>
+                    <input value={email} onChange={e => setEmail(e.target.value)} type="email" required className="w-full p-2 rounded bg-white text-black" />
+                  </div>
+                  <button type="submit" className="w-full bg-purple-600 hover:bg-purple-700 text-white py-2 rounded">Volgende</button>
+                </div>
+              )}
+              {step === 2 && (
+                <div className="space-y-4">
+                  <div>
+                    <label className="block mb-1 flex items-center">Niveau
+                      <span className="ml-2 cursor-pointer" onClick={() => setShowInfo(!showInfo)}>❔</span>
+                    </label>
+                    {showInfo && (
+                      <div className="text-xs text-purple-200 mb-2">
+                        <p><strong>Beginner</strong>: minder dan 1 jaar ervaring.</p>
+                        <p><strong>Gevorderd</strong>: 1-3 jaar regelmatig trainen.</p>
+                        <p><strong>Expert</strong>: meer dan 3 jaar fanatiek wielrennen.</p>
+                      </div>
+                    )}
+                    <select value={level} onChange={e => setLevel(e.target.value)} className="w-full p-2 rounded bg-white text-black">
+                      <option value="beginner">Beginner</option>
+                      <option value="intermediate">Gevorderd</option>
+                      <option value="advanced">Expert</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label className="block mb-1">Dagen per week</label>
+                    <input type="number" min="1" max="7" value={days} onChange={e => setDays(parseInt(e.target.value))} className="w-full p-2 rounded bg-white text-black" />
+                  </div>
+                  <div>
+                    <label className="block mb-1">FTP</label>
+                    <input type="number" value={ftp} onChange={e => setFtp(e.target.value)} className="w-full p-2 rounded bg-white text-black" />
+                  </div>
+                  <div>
+                    <label className="block mb-1">Uren per week beschikbaar</label>
+                    <input type="number" step="0.5" min="1" value={hours} onChange={e => setHours(e.target.value)} className="w-full p-2 rounded bg-white text-black" />
+                  </div>
+                  <button type="submit" className="w-full bg-purple-600 hover:bg-purple-700 text-white py-2 rounded">Genereer Schema</button>
+                </div>
+              )}
+            </form>
+          </div>
+        );
+      }
+
+      function SchemaView({ intake }) {
+        const schema = generateSchema(intake);
+        return (
+          <div className="p-4 space-y-6">
+            {schema.map(week => (
+              <div key={week.week} className="bg-white/10 rounded-lg p-4">
+                <h2 className="text-xl font-semibold mb-2">Week {week.week} - Totale TSS: {week.tss}</h2>
+                {week.workouts.map((w, i) => (
+                  <div key={i} className="border border-purple-500 rounded p-3 mb-3">
+                    <h3 className="font-medium">{w.day}: {w.title}</h3>
+                    <p className="text-sm text-purple-200 mb-1">TSS: {w.tss}</p>
+                    <ul className="list-disc list-inside text-sm mb-2">
+                      {w.blocks.map((b, j) => (
+                        <li key={j}>
+                          {b.type === 'interval' ? `${b.repeats}x ${b.minutes} min @ ${Math.round(intake.ftp * b.factor)} watt + ${b.rest} min rust @ ${Math.round(intake.ftp * b.restFactor)} watt` : `${b.minutes} min @ ${Math.round(intake.ftp * b.factor)} watt (${b.type})`}
+                        </li>
+                      ))}
+                    </ul>
+                    <button onClick={() => downloadTcx(w.title, w.blocks, intake.ftp)} className="bg-purple-600 hover:bg-purple-700 text-white py-1 px-3 rounded text-sm">Download .TCX</button>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        );
+      }
+
+      function App() {
+        const [intake, setIntake] = useState(null);
+        return intake ? <SchemaView intake={intake} /> : <TrainingIntake onComplete={setIntake} />;
+      }
+
+      ReactDOM.render(<App />, document.getElementById('root'));
+    </script>
   </body>
 </html>

--- a/src/TrainingIntake.jsx
+++ b/src/TrainingIntake.jsx
@@ -4,11 +4,24 @@ export default function TrainingIntake({ onComplete }) {
   const [level, setLevel] = useState('beginner');
   const [days, setDays] = useState(3);
   const [ftp, setFtp] = useState('');
+  const [hours, setHours] = useState('');
+  const [email, setEmail] = useState('');
 
   const handleSubmit = (e) => {
     e.preventDefault();
     const parsedFtp = parseInt(ftp);
-    onComplete({ level, days, ftp: isNaN(parsedFtp) ? 200 : parsedFtp });
+    const parsedHours = parseFloat(hours);
+    if (!email) {
+      alert('E-mailadres is verplicht');
+      return;
+    }
+    onComplete({
+      level,
+      days,
+      hours: isNaN(parsedHours) ? 5 : parsedHours,
+      ftp: isNaN(parsedFtp) ? 200 : parsedFtp,
+      email,
+    });
   };
 
   return (
@@ -51,6 +64,29 @@ export default function TrainingIntake({ onComplete }) {
             value={ftp}
             onChange={(e) => setFtp(e.target.value)}
             className="w-full border border-gray-300 p-2 rounded"
+          />
+        </div>
+
+        <div>
+          <label className="block text-gray-600 mb-1">Uren beschikbaar per week:</label>
+          <input
+            type="number"
+            value={hours}
+            onChange={(e) => setHours(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded"
+            min="1"
+            step="0.5"
+          />
+        </div>
+
+        <div>
+          <label className="block text-gray-600 mb-1">E-mailadres:</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded"
+            required
           />
         </div>
 


### PR DESCRIPTION
## Summary
- rework index.html to run with React, Babel and Tailwind via CDN
- implement 2‑step intake with email first and level info tooltip
- generate 6‑week polarized plan with TSS and TCX downloads

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.