### PR TITLE
Improve intake and schedule generation

### DIFF
--- a/src/SchemaView.jsx
+++ b/src/SchemaView.jsx
@@ -1,32 +1,149 @@
-function generateSchema({ level, days, ftp }) {
-  const planByLevel = {
-    beginner: [
-      { type: 'warmup', minutes: 10, factor: 0.55 },
-      { type: 'endurance', minutes: 30, factor: 0.65 },
-      { type: 'cooldown', minutes: 5, factor: 0.5 },
-    ],
-    intermediate: [
-      { type: 'warmup', minutes: 10, factor: 0.6 },
-      { type: 'interval', minutes: 5, factor: 1.05, repeats: 4, rest: 3, restFactor: 0.6 },
-      { type: 'cooldown', minutes: 5, factor: 0.5 },
-    ],
-    advanced: [
-      { type: 'warmup', minutes: 10, factor: 0.65 },
-      { type: 'interval', minutes: 6, factor: 1.1, repeats: 5, rest: 3, restFactor: 0.6 },
-      { type: 'cooldown', minutes: 5, factor: 0.5 },
-    ],
+function totalMinutes(blocks) {
+  return blocks.reduce((sum, b) => {
+    if (b.type === 'interval') {
+      return sum + b.repeats * (b.minutes + b.rest);
+    }
+    return sum + b.minutes;
+  }, 0);
+}
+
+function scaleBlocks(blocks, target) {
+  const base = totalMinutes(blocks);
+  const ratio = target / base;
+  return blocks.map((b) => {
+    const scaled = { ...b };
+    scaled.minutes = Math.round(b.minutes * ratio);
+    if (b.rest) scaled.rest = Math.round(b.rest * ratio);
+    return scaled;
+  });
+}
+
+function computeTss(blocks, ftp) {
+  let total = 0;
+  blocks.forEach((b) => {
+    if (b.type === 'interval') {
+      for (let i = 0; i < b.repeats; i++) {
+        total += ((b.minutes / 60) * Math.pow(b.factor, 2) * 100);
+        total += ((b.rest / 60) * Math.pow(b.restFactor, 2) * 100);
+      }
+    } else {
+      total += ((b.minutes / 60) * Math.pow(b.factor, 2) * 100);
+    }
+  });
+  return Math.round(total);
+}
+
+function generateSchema({ level, days, ftp, hours }) {
+  const plans = {
+    beginner: {
+      endurance: [
+        { type: 'warmup', minutes: 10, factor: 0.55 },
+        { type: 'endurance', minutes: 40, factor: 0.65 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      interval: [
+        { type: 'warmup', minutes: 10, factor: 0.55 },
+        { type: 'interval', minutes: 4, factor: 1.05, repeats: 5, rest: 3, restFactor: 0.55 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      tempo: [
+        { type: 'warmup', minutes: 10, factor: 0.55 },
+        { type: 'interval', minutes: 10, factor: 0.9, repeats: 3, rest: 5, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      steigerung: [
+        { type: 'warmup', minutes: 10, factor: 0.55 },
+        { type: 'interval', minutes: 2, factor: 1.1, repeats: 6, rest: 2, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      vo2max: [
+        { type: 'warmup', minutes: 10, factor: 0.55 },
+        { type: 'interval', minutes: 3, factor: 1.15, repeats: 5, rest: 3, restFactor: 0.55 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+    },
+    intermediate: {
+      endurance: [
+        { type: 'warmup', minutes: 10, factor: 0.6 },
+        { type: 'endurance', minutes: 50, factor: 0.7 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      interval: [
+        { type: 'warmup', minutes: 10, factor: 0.6 },
+        { type: 'interval', minutes: 5, factor: 1.05, repeats: 6, rest: 3, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      tempo: [
+        { type: 'warmup', minutes: 10, factor: 0.6 },
+        { type: 'interval', minutes: 12, factor: 0.9, repeats: 3, rest: 5, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      steigerung: [
+        { type: 'warmup', minutes: 10, factor: 0.6 },
+        { type: 'interval', minutes: 3, factor: 1.1, repeats: 6, rest: 3, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      vo2max: [
+        { type: 'warmup', minutes: 10, factor: 0.6 },
+        { type: 'interval', minutes: 3, factor: 1.2, repeats: 5, rest: 3, restFactor: 0.55 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+    },
+    advanced: {
+      endurance: [
+        { type: 'warmup', minutes: 10, factor: 0.65 },
+        { type: 'endurance', minutes: 60, factor: 0.75 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      interval: [
+        { type: 'warmup', minutes: 10, factor: 0.65 },
+        { type: 'interval', minutes: 6, factor: 1.1, repeats: 6, rest: 3, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      tempo: [
+        { type: 'warmup', minutes: 10, factor: 0.65 },
+        { type: 'interval', minutes: 15, factor: 0.9, repeats: 3, rest: 5, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      steigerung: [
+        { type: 'warmup', minutes: 10, factor: 0.65 },
+        { type: 'interval', minutes: 4, factor: 1.15, repeats: 6, rest: 3, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      vo2max: [
+        { type: 'warmup', minutes: 10, factor: 0.65 },
+        { type: 'interval', minutes: 4, factor: 1.2, repeats: 6, rest: 4, restFactor: 0.55 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+    },
   };
 
-  const schema = [];
-  for (let i = 0; i < days; i++) {
-    const baseBlocks = planByLevel[level];
-    schema.push({
-      day: `Dag ${i + 1}`,
-      title: `Trainingsblok ${i + 1}`,
-      blocks: baseBlocks,
-    });
+  const sessionMinutes = Math.round((hours * 60) / days);
+  const hiTypes = ['interval', 'vo2max', 'steigerung', 'tempo'];
+  const weeks = [];
+
+  for (let week = 1; week <= 6; week++) {
+    const sessions = [];
+    const hiSessions = Math.max(1, Math.round(days * 0.2));
+    for (let d = 1; d <= days; d++) {
+      const highIntensity = d <= hiSessions;
+      const type = highIntensity ? hiTypes[(week + d) % hiTypes.length] : 'endurance';
+      const base = plans[level][type];
+      const blocks = scaleBlocks(base, sessionMinutes);
+      const tss = computeTss(blocks, ftp);
+      sessions.push({
+        day: d,
+        type,
+        title: type.charAt(0).toUpperCase() + type.slice(1),
+        blocks,
+        tss,
+      });
+    }
+    const weekTss = sessions.reduce((sum, s) => sum + s.tss, 0);
+    weeks.push({ week, sessions, tss: Math.round(weekTss) });
   }
-  return schema;
+
+  return weeks;
 }
 
 function generateTcxWorkout(title, blocks, ftp) {
@@ -57,7 +174,8 @@ function generateTcxWorkout(title, blocks, ftp) {
 
   const xmlSteps = steps.map(
     (s, i) => `
-      <Step>
+      <WorkoutStep>
+        <StepId>${i + 1}</StepId>
         <Name>${s.name}</Name>
         <Duration>
           <DurationType>Time</DurationType>
@@ -65,9 +183,10 @@ function generateTcxWorkout(title, blocks, ftp) {
         </Duration>
         <Target>
           <TargetType>Power</TargetType>
-          <PowerZone>${s.power}</PowerZone>
+          <CustomTargetValueLow>${s.power}</CustomTargetValueLow>
+          <CustomTargetValueHigh>${s.power}</CustomTargetValueHigh>
         </Target>
-      </Step>`
+      </WorkoutStep>`
   ).join('');
 
   return `<?xml version="1.0" encoding="UTF-8"?>
@@ -75,7 +194,9 @@ function generateTcxWorkout(title, blocks, ftp) {
   <Workouts>
     <Workout Sport="Biking">
       <Name>${title}</Name>
-      ${xmlSteps}
+      <Steps>
+        ${xmlSteps}
+      </Steps>
     </Workout>
   </Workouts>
 </TrainingCenterDatabase>`;
@@ -91,39 +212,44 @@ function downloadTcx(title, blocks, ftp) {
 }
 
 export default function SchemaView({ intake, onUpdateFtp }) {
-  const schema = generateSchema(intake);
+  const weeks = generateSchema(intake);
 
   return (
-    <div className="min-h-screen bg-gray-100 p-6">
-      <div className="max-w-3xl mx-auto bg-white shadow rounded-lg p-6 space-y-6">
-        <h1 className="text-3xl font-bold text-gray-800">Trainingsschema</h1>
+    <div className="min-h-screen bg-gradient-to-b from-purple-800 via-purple-900 to-black p-6 text-white">
+      <div className="max-w-3xl mx-auto bg-white text-gray-800 shadow rounded-lg p-6 space-y-6">
+        <h1 className="text-3xl font-bold">Trainingsschema</h1>
         <p className="text-gray-600">
-          Niveau: <strong>{intake.level}</strong> · Dagen/week: <strong>{intake.days}</strong> · FTP: <strong>{intake.ftp} watt</strong>
+          Niveau: <strong>{intake.level}</strong> · Dagen/week: <strong>{intake.days}</strong> · Uren/week: <strong>{intake.hours}</strong> · FTP: <strong>{intake.ftp} watt</strong>
         </p>
 
-        <div className="grid gap-4">
-          {schema.map((item, index) => (
-            <div key={index} className="bg-blue-50 p-4 rounded shadow-sm border border-blue-200">
-              <h2 className="text-xl font-semibold text-blue-800">{item.day}</h2>
-              <p className="text-gray-700 mb-2">Trainingsvorm: <strong>{item.title}</strong></p>
-              <ul className="list-disc ml-5 text-gray-600">
-                {item.blocks.map((b, i) => (
-                  <li key={i}>
-                    {b.type === 'interval'
-                      ? `${b.repeats}x ${b.minutes} min @ ${Math.round(intake.ftp * b.factor)} watt + ${b.rest} min rust @ ${Math.round(intake.ftp * b.restFactor)} watt`
-                      : `${b.minutes} min @ ${Math.round(intake.ftp * b.factor)} watt (${b.type})`}
-                  </li>
-                ))}
-              </ul>
-              <button
-                onClick={() => downloadTcx(item.title, item.blocks, intake.ftp)}
-                className="mt-3 inline-block bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
-              >
-                Download .TCX
-              </button>
+        {weeks.map((week) => (
+          <div key={week.week} className="space-y-4">
+            <h2 className="text-2xl font-semibold text-purple-800">Week {week.week} – TSS {week.tss}</h2>
+            <div className="grid gap-4">
+              {week.sessions.map((item, index) => (
+                <div key={index} className="bg-purple-50 p-4 rounded shadow-sm">
+                  <h3 className="text-lg font-semibold text-purple-800">Dag {item.day}: {item.title}</h3>
+                  <p className="text-gray-700 mb-2">Sessie TSS: {item.tss}</p>
+                  <ul className="list-disc ml-5 text-gray-600">
+                    {item.blocks.map((b, i) => (
+                      <li key={i}>
+                        {b.type === 'interval'
+                          ? `${b.repeats}x ${b.minutes} min @ ${Math.round(intake.ftp * b.factor)} watt + ${b.rest} min rust @ ${Math.round(intake.ftp * b.restFactor)} watt`
+                          : `${b.minutes} min @ ${Math.round(intake.ftp * b.factor)} watt (${b.type})`}
+                      </li>
+                    ))}
+                  </ul>
+                  <button
+                    onClick={() => downloadTcx(`${week.week}-${item.day}-${item.title}`, item.blocks, intake.ftp)}
+                    className="mt-3 inline-block bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+                  >
+                    Download .TCX
+                  </button>
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
+          </div>
+        ))}
 
         <div className="pt-4">
           <label className="block text-gray-700 font-medium mb-1">Update je FTP:</label>

--- a/src/TrainingIntake.jsx
+++ b/src/TrainingIntake.jsx
@@ -4,61 +4,109 @@ export default function TrainingIntake({ onComplete }) {
   const [level, setLevel] = useState('beginner');
   const [days, setDays] = useState(3);
   const [ftp, setFtp] = useState('');
+  const [hours, setHours] = useState('');
+  const [email, setEmail] = useState('');
+  const [step, setStep] = useState(1);
 
-  const handleSubmit = (e) => {
+  const handleNext = (e) => {
     e.preventDefault();
+    if (step === 1) {
+      if (!email) {
+        alert('E-mailadres is verplicht');
+        return;
+      }
+      setStep(2);
+      return;
+    }
     const parsedFtp = parseInt(ftp);
-    onComplete({ level, days, ftp: isNaN(parsedFtp) ? 200 : parsedFtp });
+    const parsedHours = parseFloat(hours);
+    onComplete({
+      level,
+      days,
+      hours: isNaN(parsedHours) ? 5 : parsedHours,
+      ftp: isNaN(parsedFtp) ? 200 : parsedFtp,
+      email,
+    });
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-purple-800 via-purple-900 to-black p-6">
       <form
-        onSubmit={handleSubmit}
+        onSubmit={handleNext}
         className="bg-white p-8 rounded shadow-md w-full max-w-md space-y-6"
       >
-        <h2 className="text-2xl font-bold text-center text-gray-700">Trainingsintake</h2>
+        <h1 className="text-3xl font-bold text-center text-gray-800">Gratis 6 Weken Trainingsschema</h1>
+        <p className="text-center text-gray-600">Vul je gegevens in en ontvang direct een gepersonaliseerd schema.</p>
 
-        <div>
-          <label className="block text-gray-600 mb-1">Niveau:</label>
-          <select
-            value={level}
-            onChange={(e) => setLevel(e.target.value)}
-            className="w-full border border-gray-300 p-2 rounded"
-          >
-            <option value="beginner">Beginner</option>
-            <option value="intermediate">Gevorderd</option>
-            <option value="advanced">Expert</option>
-          </select>
-        </div>
+        {step === 1 && (
+          <div>
+            <label className="block text-gray-600 mb-1">E-mailadres:</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full border border-gray-300 p-2 rounded bg-white"
+              required
+            />
+          </div>
+        )}
 
-        <div>
-          <label className="block text-gray-600 mb-1">Dagen per week:</label>
-          <input
-            type="number"
-            value={days}
-            onChange={(e) => setDays(Number(e.target.value))}
-            className="w-full border border-gray-300 p-2 rounded"
-            min="1"
-            max="7"
-          />
-        </div>
+        {step === 2 && (
+          <>
+            <div>
+              <label className="block text-gray-600 mb-1">Niveau:</label>
+              <select
+                value={level}
+                onChange={(e) => setLevel(e.target.value)}
+                className="w-full border border-gray-300 p-2 rounded bg-white"
+              >
+                <option value="beginner">Beginner</option>
+                <option value="intermediate">Gevorderd</option>
+                <option value="advanced">Expert</option>
+              </select>
+            </div>
 
-        <div>
-          <label className="block text-gray-600 mb-1">FTP:</label>
-          <input
-            type="number"
-            value={ftp}
-            onChange={(e) => setFtp(e.target.value)}
-            className="w-full border border-gray-300 p-2 rounded"
-          />
-        </div>
+            <div>
+              <label className="block text-gray-600 mb-1">Dagen per week:</label>
+              <input
+                type="number"
+                value={days}
+                onChange={(e) => setDays(Number(e.target.value))}
+                className="w-full border border-gray-300 p-2 rounded bg-white"
+                min="1"
+                max="7"
+              />
+            </div>
+
+            <div>
+              <label className="block text-gray-600 mb-1">FTP:</label>
+              <input
+                type="number"
+                value={ftp}
+                onChange={(e) => setFtp(e.target.value)}
+                className="w-full border border-gray-300 p-2 rounded bg-white"
+              />
+            </div>
+
+            <div>
+              <label className="block text-gray-600 mb-1">Uren beschikbaar per week:</label>
+              <input
+                type="number"
+                value={hours}
+                onChange={(e) => setHours(e.target.value)}
+                className="w-full border border-gray-300 p-2 rounded bg-white"
+                min="1"
+                step="0.5"
+              />
+            </div>
+          </>
+        )}
 
         <button
           type="submit"
-          className="w-full bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600"
+          className="w-full bg-purple-700 text-white py-2 px-4 rounded hover:bg-purple-800"
         >
-          Genereer Schema
+          {step === 1 ? 'Volgende' : 'Genereer Schema'}
         </button>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- add multi-step email-first intake form with gradient styling
- generate polarized 6-week plans with varied workouts and TSS per session
- show weekly TSS totals and download TCX files with Garmin-compatible steps

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*