### PR TITLE
Improve intake and schedule generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/SchemaView.jsx
+++ b/src/SchemaView.jsx
@@ -1,63 +1,168 @@
-function generateSchema({ level, days, ftp }) {
-  const planByLevel = {
-    beginner: [
-      { type: 'warmup', minutes: 10, factor: 0.55 },
-      { type: 'endurance', minutes: 30, factor: 0.65 },
-      { type: 'cooldown', minutes: 5, factor: 0.5 },
-    ],
-    intermediate: [
-      { type: 'warmup', minutes: 10, factor: 0.6 },
-      { type: 'interval', minutes: 5, factor: 1.05, repeats: 4, rest: 3, restFactor: 0.6 },
-      { type: 'cooldown', minutes: 5, factor: 0.5 },
-    ],
-    advanced: [
-      { type: 'warmup', minutes: 10, factor: 0.65 },
-      { type: 'interval', minutes: 6, factor: 1.1, repeats: 5, rest: 3, restFactor: 0.6 },
-      { type: 'cooldown', minutes: 5, factor: 0.5 },
-    ],
+function totalMinutes(blocks) {
+  return blocks.reduce((sum, b) => {
+    if (b.type === 'interval') {
+      return sum + b.repeats * (b.minutes + b.rest);
+    }
+    return sum + b.minutes;
+  }, 0);
+}
+
+function scaleBlocks(blocks, target) {
+  const base = totalMinutes(blocks);
+  const ratio = target / base;
+  return blocks.map((b) => {
+    const scaled = { ...b };
+    scaled.minutes = Math.round(b.minutes * ratio);
+    if (b.rest) scaled.rest = Math.round(b.rest * ratio);
+    return scaled;
+  });
+}
+
+function computeTss(blocks) {
+  let tss = 0;
+  blocks.forEach((b) => {
+    if (b.type === 'interval') {
+      for (let i = 0; i < b.repeats; i++) {
+        tss += (b.minutes / 60) * b.factor * b.factor * 100;
+        tss += (b.rest / 60) * b.restFactor * b.restFactor * 100;
+      }
+    } else {
+      tss += (b.minutes / 60) * b.factor * b.factor * 100;
+    }
+  });
+  return Math.round(tss);
+}
+
+function generateSchema({ level, days, ftp, hours }) {
+  const plans = {
+    beginner: {
+      endurance: [
+        { type: 'warmup', minutes: 10, factor: 0.55 },
+        { type: 'endurance', minutes: 40, factor: 0.65 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      interval: [
+        { type: 'warmup', minutes: 10, factor: 0.55 },
+        { type: 'interval', minutes: 4, factor: 1.05, repeats: 5, rest: 3, restFactor: 0.55 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      vo2max: [
+        { type: 'warmup', minutes: 10, factor: 0.6 },
+        { type: 'interval', minutes: 3, factor: 1.2, repeats: 6, rest: 3, restFactor: 0.55 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      tempo: [
+        { type: 'warmup', minutes: 10, factor: 0.55 },
+        { type: 'tempo', minutes: 20, factor: 0.9 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      steigerung: [
+        { type: 'warmup', minutes: 10, factor: 0.55 },
+        { type: 'steigerung', minutes: 20, factor: 1.0 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+    },
+    intermediate: {
+      endurance: [
+        { type: 'warmup', minutes: 10, factor: 0.6 },
+        { type: 'endurance', minutes: 50, factor: 0.7 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      interval: [
+        { type: 'warmup', minutes: 10, factor: 0.6 },
+        { type: 'interval', minutes: 5, factor: 1.05, repeats: 6, rest: 3, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      vo2max: [
+        { type: 'warmup', minutes: 10, factor: 0.65 },
+        { type: 'interval', minutes: 4, factor: 1.2, repeats: 6, rest: 3, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      tempo: [
+        { type: 'warmup', minutes: 10, factor: 0.6 },
+        { type: 'tempo', minutes: 25, factor: 0.9 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      steigerung: [
+        { type: 'warmup', minutes: 10, factor: 0.6 },
+        { type: 'steigerung', minutes: 25, factor: 1.0 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+    },
+    advanced: {
+      endurance: [
+        { type: 'warmup', minutes: 10, factor: 0.65 },
+        { type: 'endurance', minutes: 60, factor: 0.75 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      interval: [
+        { type: 'warmup', minutes: 10, factor: 0.65 },
+        { type: 'interval', minutes: 6, factor: 1.1, repeats: 6, rest: 3, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      vo2max: [
+        { type: 'warmup', minutes: 10, factor: 0.7 },
+        { type: 'interval', minutes: 5, factor: 1.25, repeats: 6, rest: 4, restFactor: 0.6 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      tempo: [
+        { type: 'warmup', minutes: 10, factor: 0.65 },
+        { type: 'tempo', minutes: 30, factor: 0.9 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+      steigerung: [
+        { type: 'warmup', minutes: 10, factor: 0.65 },
+        { type: 'steigerung', minutes: 30, factor: 1.05 },
+        { type: 'cooldown', minutes: 5, factor: 0.5 },
+      ],
+    },
   };
 
-  const schema = [];
-  for (let i = 0; i < days; i++) {
-    const baseBlocks = planByLevel[level];
-    schema.push({
-      day: `Dag ${i + 1}`,
-      title: `Trainingsblok ${i + 1}`,
-      blocks: baseBlocks,
-    });
+  const order = ['interval', 'vo2max', 'steigerung', 'tempo'];
+  const sessionMinutes = Math.round((hours * 60) / days);
+  const hiSessions = Math.max(1, Math.round(days * 0.2));
+  const weeks = [];
+
+  for (let week = 1; week <= 6; week++) {
+    const sessions = [];
+    let weekTss = 0;
+    for (let d = 1; d <= days; d++) {
+      const highIntensity = d <= hiSessions;
+      const type = highIntensity ? order[(week + d) % order.length] : 'endurance';
+      const base = plans[level][type];
+      const blocks = scaleBlocks(base, sessionMinutes);
+      const tss = computeTss(blocks);
+      weekTss += tss;
+      sessions.push({
+        day: `Dag ${d}`,
+        title: type,
+        blocks,
+        tss,
+      });
+    }
+    weeks.push({ week, sessions, tss: weekTss });
   }
-  return schema;
+
+  return weeks;
 }
 
 function generateTcxWorkout(title, blocks, ftp) {
   const steps = [];
-
-  blocks.forEach((block, index) => {
+  blocks.forEach((block) => {
     if (block.type === 'interval') {
       for (let i = 0; i < block.repeats; i++) {
-        steps.push({
-          name: `Interval ${i + 1}`,
-          duration: block.minutes * 60,
-          power: Math.round(ftp * block.factor),
-        });
-        steps.push({
-          name: `Rust ${i + 1}`,
-          duration: block.rest * 60,
-          power: Math.round(ftp * block.restFactor),
-        });
+        steps.push({ name: `Interval ${i + 1}`, duration: block.minutes * 60, power: Math.round(ftp * block.factor) });
+        steps.push({ name: `Rust ${i + 1}`, duration: block.rest * 60, power: Math.round(ftp * block.restFactor) });
       }
     } else {
-      steps.push({
-        name: block.type.charAt(0).toUpperCase() + block.type.slice(1),
-        duration: block.minutes * 60,
-        power: Math.round(ftp * block.factor),
-      });
+      steps.push({ name: block.type, duration: block.minutes * 60, power: Math.round(ftp * block.factor) });
     }
   });
 
-  const xmlSteps = steps.map(
-    (s, i) => `
-      <Step>
+  const xmlSteps = steps
+    .map(
+      (s, i) => `      <WorkoutStep>
+        <StepId>${i + 1}</StepId>
         <Name>${s.name}</Name>
         <Duration>
           <DurationType>Time</DurationType>
@@ -65,20 +170,14 @@ function generateTcxWorkout(title, blocks, ftp) {
         </Duration>
         <Target>
           <TargetType>Power</TargetType>
-          <PowerZone>${s.power}</PowerZone>
+          <CustomTargetValueLow>${s.power - 5}</CustomTargetValueLow>
+          <CustomTargetValueHigh>${s.power + 5}</CustomTargetValueHigh>
         </Target>
-      </Step>`
-  ).join('');
+      </WorkoutStep>`
+    )
+    .join('\n');
 
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<TrainingCenterDatabase xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2">
-  <Workouts>
-    <Workout Sport="Biking">
-      <Name>${title}</Name>
-      ${xmlSteps}
-    </Workout>
-  </Workouts>
-</TrainingCenterDatabase>`;
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<TrainingCenterDatabase xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2">\n  <Workouts>\n    <Workout Sport="Biking">\n      <Name>${title}</Name>\n${xmlSteps}\n    </Workout>\n  </Workouts>\n</TrainingCenterDatabase>`;
 }
 
 function downloadTcx(title, blocks, ftp) {
@@ -91,40 +190,42 @@ function downloadTcx(title, blocks, ftp) {
 }
 
 export default function SchemaView({ intake, onUpdateFtp }) {
-  const schema = generateSchema(intake);
-
+  const weeks = generateSchema(intake);
   return (
-    <div className="min-h-screen bg-gray-100 p-6">
-      <div className="max-w-3xl mx-auto bg-white shadow rounded-lg p-6 space-y-6">
-        <h1 className="text-3xl font-bold text-gray-800">Trainingsschema</h1>
-        <p className="text-gray-600">
-          Niveau: <strong>{intake.level}</strong> · Dagen/week: <strong>{intake.days}</strong> · FTP: <strong>{intake.ftp} watt</strong>
+    <div className="min-h-screen bg-gradient-to-b from-purple-600 to-black p-6 text-white">
+      <div className="max-w-3xl mx-auto bg-white text-gray-800 shadow rounded-lg p-6 space-y-6">
+        <h1 className="text-3xl font-bold text-center">Trainingsschema</h1>
+        <p className="text-gray-700 text-center">
+          Niveau: <strong>{intake.level}</strong> · Dagen/week: <strong>{intake.days}</strong> · Uren/week: <strong>{intake.hours}</strong> · FTP: <strong>{intake.ftp} watt</strong>
         </p>
-
-        <div className="grid gap-4">
-          {schema.map((item, index) => (
-            <div key={index} className="bg-blue-50 p-4 rounded shadow-sm border border-blue-200">
-              <h2 className="text-xl font-semibold text-blue-800">{item.day}</h2>
-              <p className="text-gray-700 mb-2">Trainingsvorm: <strong>{item.title}</strong></p>
-              <ul className="list-disc ml-5 text-gray-600">
-                {item.blocks.map((b, i) => (
-                  <li key={i}>
-                    {b.type === 'interval'
-                      ? `${b.repeats}x ${b.minutes} min @ ${Math.round(intake.ftp * b.factor)} watt + ${b.rest} min rust @ ${Math.round(intake.ftp * b.restFactor)} watt`
-                      : `${b.minutes} min @ ${Math.round(intake.ftp * b.factor)} watt (${b.type})`}
-                  </li>
-                ))}
-              </ul>
-              <button
-                onClick={() => downloadTcx(item.title, item.blocks, intake.ftp)}
-                className="mt-3 inline-block bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
-              >
-                Download .TCX
-              </button>
+        {weeks.map((week) => (
+          <div key={week.week} className="border-t pt-4">
+            <h2 className="text-2xl font-semibold mb-2">Week {week.week} – TSS {week.tss}</h2>
+            <div className="grid gap-4">
+              {week.sessions.map((s, idx) => (
+                <div key={idx} className="bg-purple-50 p-4 rounded">
+                  <h3 className="font-semibold">{s.day}: {s.title}</h3>
+                  <ul className="list-disc ml-5 text-sm">
+                    {s.blocks.map((b, i) => (
+                      <li key={i}>
+                        {b.type === 'interval'
+                          ? `${b.repeats}x ${b.minutes}m @ ${Math.round(intake.ftp * b.factor)}w + ${b.rest}m rust`
+                          : `${b.minutes}m @ ${Math.round(intake.ftp * b.factor)}w (${b.type})`}
+                      </li>
+                    ))}
+                  </ul>
+                  <p className="text-sm mt-1">TSS: {s.tss}</p>
+                  <button
+                    onClick={() => downloadTcx(`${s.day}-${s.title}`, s.blocks, intake.ftp)}
+                    className="mt-2 inline-block bg-green-600 text-white px-3 py-1 rounded hover:bg-green-700"
+                  >
+                    Download .TCX
+                  </button>
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
-
+          </div>
+        ))}
         <div className="pt-4">
           <label className="block text-gray-700 font-medium mb-1">Update je FTP:</label>
           <input

--- a/src/TrainingIntake.jsx
+++ b/src/TrainingIntake.jsx
@@ -4,62 +4,113 @@ export default function TrainingIntake({ onComplete }) {
   const [level, setLevel] = useState('beginner');
   const [days, setDays] = useState(3);
   const [ftp, setFtp] = useState('');
+  const [hours, setHours] = useState('');
+  const [email, setEmail] = useState('');
+  const [step, setStep] = useState(1);
 
   const handleSubmit = (e) => {
     e.preventDefault();
     const parsedFtp = parseInt(ftp);
-    onComplete({ level, days, ftp: isNaN(parsedFtp) ? 200 : parsedFtp });
+    const parsedHours = parseFloat(hours);
+    if (!email) {
+      alert('E-mailadres is verplicht');
+      return;
+    }
+    onComplete({
+      level,
+      days,
+      hours: isNaN(parsedHours) ? 5 : parsedHours,
+      ftp: isNaN(parsedFtp) ? 200 : parsedFtp,
+      email,
+    });
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
-      <form
-        onSubmit={handleSubmit}
-        className="bg-white p-8 rounded shadow-md w-full max-w-md space-y-6"
-      >
-        <h2 className="text-2xl font-bold text-center text-gray-700">Trainingsintake</h2>
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-purple-600 to-black p-6">
+      <form onSubmit={handleSubmit} className="bg-white/90 p-8 rounded shadow-md w-full max-w-md space-y-6 text-gray-800">
+        <h1 className="text-3xl font-bold text-center">Gratis 6 Weken Trainingsschema</h1>
+        <p className="text-center text-sm text-gray-600">Vul je gegevens in en ontvang een persoonlijk schema.</p>
 
-        <div>
-          <label className="block text-gray-600 mb-1">Niveau:</label>
-          <select
-            value={level}
-            onChange={(e) => setLevel(e.target.value)}
-            className="w-full border border-gray-300 p-2 rounded"
+        {step === 1 && (
+          <div>
+            <label className="block text-gray-700 mb-1">E-mailadres:</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full border border-gray-300 p-2 rounded"
+              required
+            />
+          </div>
+        )}
+
+        {step === 2 && (
+          <>
+            <div>
+              <label className="block text-gray-700 mb-1">Niveau:</label>
+              <select
+                value={level}
+                onChange={(e) => setLevel(e.target.value)}
+                className="w-full border border-gray-300 p-2 rounded"
+              >
+                <option value="beginner">Beginner</option>
+                <option value="intermediate">Gevorderd</option>
+                <option value="advanced">Expert</option>
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-gray-700 mb-1">Dagen per week:</label>
+              <input
+                type="number"
+                value={days}
+                onChange={(e) => setDays(Number(e.target.value))}
+                className="w-full border border-gray-300 p-2 rounded"
+                min="1"
+                max="7"
+              />
+            </div>
+
+            <div>
+              <label className="block text-gray-700 mb-1">FTP:</label>
+              <input
+                type="number"
+                value={ftp}
+                onChange={(e) => setFtp(e.target.value)}
+                className="w-full border border-gray-300 p-2 rounded"
+              />
+            </div>
+
+            <div>
+              <label className="block text-gray-700 mb-1">Uren beschikbaar per week:</label>
+              <input
+                type="number"
+                value={hours}
+                onChange={(e) => setHours(e.target.value)}
+                className="w-full border border-gray-300 p-2 rounded"
+                min="1"
+                step="0.5"
+              />
+            </div>
+          </>
+        )}
+
+        {step === 1 ? (
+          <button
+            type="button"
+            onClick={() => (email ? setStep(2) : alert('E-mailadres is verplicht'))}
+            className="w-full bg-purple-600 text-white py-2 px-4 rounded hover:bg-purple-700"
           >
-            <option value="beginner">Beginner</option>
-            <option value="intermediate">Gevorderd</option>
-            <option value="advanced">Expert</option>
-          </select>
-        </div>
-
-        <div>
-          <label className="block text-gray-600 mb-1">Dagen per week:</label>
-          <input
-            type="number"
-            value={days}
-            onChange={(e) => setDays(Number(e.target.value))}
-            className="w-full border border-gray-300 p-2 rounded"
-            min="1"
-            max="7"
-          />
-        </div>
-
-        <div>
-          <label className="block text-gray-600 mb-1">FTP:</label>
-          <input
-            type="number"
-            value={ftp}
-            onChange={(e) => setFtp(e.target.value)}
-            className="w-full border border-gray-300 p-2 rounded"
-          />
-        </div>
-
-        <button
-          type="submit"
-          className="w-full bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600"
-        >
-          Genereer Schema
-        </button>
+            Volgende
+          </button>
+        ) : (
+          <button
+            type="submit"
+            className="w-full bg-purple-600 text-white py-2 px-4 rounded hover:bg-purple-700"
+          >
+            Genereer Schema
+          </button>
+        )}
       </form>
     </div>
   );


### PR DESCRIPTION
## Summary
- implement multi-step intake flow with email first
- show heading "Gratis 6 Weken Trainingsschema" and short description
- generate weekly polarized plan with varied sessions and TSS totals
- export Garmin-compatible TCX files per workout
- ignore node_modules

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*
