### PR TITLE
Make index standalone with inline React

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,251 @@
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="nl">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Wielren Schema App</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
   </head>
-  <body>
+  <body class="min-h-screen bg-gradient-to-b from-purple-700 to-black">
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="text/babel">
+      const { useState } = React;
+
+      function computeTss(blocks, ftp) {
+        let total = 0;
+        blocks.forEach((b) => {
+          if (b.type === 'interval') {
+            for (let i = 0; i < b.repeats; i++) {
+              total += (b.minutes / 60) * Math.pow(b.factor, 2) * 100;
+              total += (b.rest / 60) * Math.pow(b.restFactor, 2) * 100;
+            }
+          } else {
+            total += (b.minutes / 60) * Math.pow(b.factor, 2) * 100;
+          }
+        });
+        return Math.round(total);
+      }
+
+      function totalMinutes(blocks) {
+        return blocks.reduce((sum, b) => {
+          if (b.type === 'interval') return sum + b.repeats * (b.minutes + b.rest);
+          return sum + b.minutes;
+        }, 0);
+      }
+
+      function scaleBlocks(blocks, target) {
+        const base = totalMinutes(blocks);
+        const ratio = target / base;
+        return blocks.map((b) => {
+          const scaled = { ...b };
+          scaled.minutes = Math.round(b.minutes * ratio);
+          if (b.rest) scaled.rest = Math.round(b.rest * ratio);
+          return scaled;
+        });
+      }
+
+      function generateSchema({ level, days, ftp, hours }) {
+        const templates = {
+          endurance: [
+            { type: 'warmup', minutes: 10, factor: 0.55 },
+            { type: 'endurance', minutes: 40, factor: 0.65 },
+            { type: 'cooldown', minutes: 5, factor: 0.5 },
+          ],
+          tempo: [
+            { type: 'warmup', minutes: 10, factor: 0.6 },
+            { type: 'tempo', minutes: 20, factor: 0.9 },
+            { type: 'cooldown', minutes: 5, factor: 0.5 },
+          ],
+          steigerung: [
+            { type: 'warmup', minutes: 10, factor: 0.6 },
+            { type: 'steigerung', minutes: 15, factor: 0.75, ramp: 1.1 },
+            { type: 'cooldown', minutes: 5, factor: 0.5 },
+          ],
+          vo2max: [
+            { type: 'warmup', minutes: 10, factor: 0.6 },
+            { type: 'interval', minutes: 3, factor: 1.2, repeats: 5, rest: 3, restFactor: 0.55 },
+            { type: 'cooldown', minutes: 5, factor: 0.5 },
+          ],
+          interval: [
+            { type: 'warmup', minutes: 10, factor: 0.55 },
+            { type: 'interval', minutes: 4, factor: 1.05, repeats: 5, rest: 3, restFactor: 0.55 },
+            { type: 'cooldown', minutes: 5, factor: 0.5 },
+          ],
+        };
+
+        const sessionMinutes = Math.round((hours * 60) / days);
+        const hiTypes = ['interval', 'vo2max', 'steigerung', 'tempo'];
+
+        const schedule = [];
+        for (let week = 1; week <= 6; week++) {
+          const hiSessions = Math.max(1, Math.round(days * 0.2));
+          const weekSessions = [];
+          for (let d = 1; d <= days; d++) {
+            const high = d <= hiSessions;
+            const type = high ? hiTypes[(week + d) % hiTypes.length] : 'endurance';
+            const blocks = scaleBlocks(templates[type], sessionMinutes);
+            const tss = computeTss(blocks, ftp);
+            weekSessions.push({ day: d, title: type, blocks, tss });
+          }
+          const weekTss = weekSessions.reduce((s, w) => s + w.tss, 0);
+          schedule.push({ week, sessions: weekSessions, tss: weekTss });
+        }
+        return schedule;
+      }
+
+      function generateTcxWorkout(title, blocks, ftp) {
+        const steps = [];
+        blocks.forEach((b) => {
+          if (b.type === 'interval') {
+            for (let i = 0; i < b.repeats; i++) {
+              steps.push({ name: `${b.type} ${i + 1}`, seconds: b.minutes * 60, target: ftp * b.factor });
+              steps.push({ name: `Rust ${i + 1}`, seconds: b.rest * 60, target: ftp * b.restFactor });
+            }
+          } else {
+            steps.push({ name: b.type, seconds: b.minutes * 60, target: ftp * b.factor });
+          }
+        });
+        const xmlSteps = steps
+          .map(
+            (s, i) => `\n        <WorkoutStep>\n          <StepId>${i + 1}</StepId>\n          <Name>${s.name}</Name>\n          <Duration>\n            <DurationType>Time</DurationType>\n            <Seconds>${s.seconds}</Seconds>\n          </Duration>\n          <Target>\n            <TargetType>Power</TargetType>\n            <CustomTargetValueLow>${Math.round(s.target * 0.95)}</CustomTargetValueLow>\n            <CustomTargetValueHigh>${Math.round(s.target * 1.05)}</CustomTargetValueHigh>\n          </Target>\n        </WorkoutStep>`
+          )
+          .join('');
+
+        return `<?xml version="1.0" encoding="UTF-8"?>\n<TrainingCenterDatabase xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2">\n  <Workouts>\n    <Workout Sport="Biking">\n      <Name>${title}</Name>\n      <Steps>${xmlSteps}\n      </Steps>\n    </Workout>\n  </Workouts>\n</TrainingCenterDatabase>`;
+      }
+
+      function downloadTcx(title, blocks, ftp) {
+        const xml = generateTcxWorkout(title, blocks, ftp);
+        const blob = new Blob([xml], { type: 'application/xml' });
+        const link = document.createElement('a');
+        link.href = URL.createObjectURL(blob);
+        link.download = title.replace(/\s+/g, '_') + '.tcx';
+        link.click();
+      }
+
+      function TrainingIntake({ onComplete }) {
+        const [step, setStep] = useState(1);
+        const [email, setEmail] = useState('');
+        const [ftp, setFtp] = useState('');
+        const [hours, setHours] = useState('');
+        const [days, setDays] = useState(3);
+        const [level, setLevel] = useState('beginner');
+
+        const next = (e) => {
+          e.preventDefault();
+          if (!email) {
+            alert('E-mailadres is verplicht');
+            return;
+          }
+          setStep(2);
+        };
+
+        const submit = (e) => {
+          e.preventDefault();
+          const parsedFtp = parseInt(ftp);
+          const parsedHours = parseFloat(hours);
+          onComplete({
+            email,
+            days: parseInt(days) || 3,
+            level,
+            ftp: isNaN(parsedFtp) ? 200 : parsedFtp,
+            hours: isNaN(parsedHours) ? 5 : parsedHours,
+          });
+        };
+
+        return (
+          <div className="flex items-center justify-center min-h-screen text-gray-800">
+            <form onSubmit={step === 1 ? next : submit} className="bg-white p-6 rounded shadow w-full max-w-md space-y-4">
+              <h1 className="text-2xl font-bold text-center">Gratis 6 Weken Trainingsschema</h1>
+              {step === 1 && (
+                <>
+                  <p className="text-sm text-center">Laat je e-mailadres achter voor gratis toegang.</p>
+                  <input type="email" value={email} onChange={(e) => setEmail(e.target.value)} className="w-full border p-2 rounded" placeholder="E-mailadres" required />
+                  <button type="submit" className="w-full bg-purple-600 text-white py-2 rounded">Volgende</button>
+                </>
+              )}
+              {step === 2 && (
+                <>
+                  <div>
+                    <label className="block mb-1">FTP (watt)</label>
+                    <input type="number" value={ftp} onChange={(e) => setFtp(e.target.value)} className="w-full border p-2 rounded" />
+                  </div>
+                  <div>
+                    <label className="block mb-1">Uren per week</label>
+                    <input type="number" value={hours} onChange={(e) => setHours(e.target.value)} className="w-full border p-2 rounded" min="1" step="0.5" />
+                  </div>
+                  <div>
+                    <label className="block mb-1">Dagen per week</label>
+                    <input type="number" value={days} onChange={(e) => setDays(e.target.value)} className="w-full border p-2 rounded" min="1" max="7" />
+                  </div>
+                  <div>
+                    <label className="block mb-1">Niveau <span title="Beginner: nieuw, Gevorderd: ervaring, Expert: wedstrijdrijder" className="ml-1 cursor-pointer text-blue-600">i</span></label>
+                    <select value={level} onChange={(e) => setLevel(e.target.value)} className="w-full border p-2 rounded">
+                      <option value="beginner">Beginner</option>
+                      <option value="intermediate">Gevorderd</option>
+                      <option value="advanced">Expert</option>
+                    </select>
+                  </div>
+                  <button type="submit" className="w-full bg-purple-600 text-white py-2 rounded">Genereer Schema</button>
+                </>
+              )}
+            </form>
+          </div>
+        );
+      }
+
+      function SchemaView({ intake }) {
+        const [ftp, setFtp] = useState(intake.ftp);
+        const schedule = generateSchema({ ...intake, ftp });
+
+        return (
+          <div className="min-h-screen p-4 text-white bg-gradient-to-b from-purple-700 to-black">
+            <div className="max-w-3xl mx-auto space-y-6">
+              <h2 className="text-3xl font-bold">Trainingsschema</h2>
+              <p>
+                Niveau: {intake.level} · Dagen/week: {intake.days} · Uren/week: {intake.hours} · FTP: {ftp} watt
+              </p>
+              {schedule.map((week) => (
+                <div key={week.week} className="bg-white text-gray-800 rounded shadow p-4 space-y-2">
+                  <h3 className="text-xl font-semibold">Week {week.week} – TSS {week.tss}</h3>
+                  {week.sessions.map((s, idx) => (
+                    <div key={idx} className="border-t pt-2">
+                      <p className="font-medium">Dag {s.day}: {s.title} (TSS {s.tss})</p>
+                      <ul className="list-disc ml-6">
+                        {s.blocks.map((b, i) => (
+                          <li key={i}>
+                            {b.type === 'interval'
+                              ? `${b.repeats}x ${b.minutes} min @ ${Math.round(ftp * b.factor)}w + ${b.rest} min rust @ ${Math.round(ftp * b.restFactor)}w`
+                              : `${b.minutes} min @ ${Math.round(ftp * b.factor)}w (${b.type})`}
+                          </li>
+                        ))}
+                      </ul>
+                      <button onClick={() => downloadTcx(`Week${week.week}_Day${s.day}`, s.blocks, ftp)} className="mt-2 bg-green-600 text-white px-3 py-1 rounded">
+                        Download .TCX
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              ))}
+              <div className="bg-white text-gray-800 p-4 rounded shadow">
+                <label className="block mb-1 font-medium">Update je FTP:</label>
+                <input type="number" value={ftp} onChange={(e) => setFtp(parseInt(e.target.value) || ftp)} className="w-full border p-2 rounded" />
+              </div>
+            </div>
+          </div>
+        );
+      }
+
+      function App() {
+        const [intake, setIntake] = useState(null);
+        return intake ? <SchemaView intake={intake} /> : <TrainingIntake onComplete={setIntake} />;
+      }
+
+      ReactDOM.render(<App />, document.getElementById('root'));
+    </script>
   </body>
 </html>

--- a/src/TrainingIntake.jsx
+++ b/src/TrainingIntake.jsx
@@ -4,11 +4,24 @@ export default function TrainingIntake({ onComplete }) {
   const [level, setLevel] = useState('beginner');
   const [days, setDays] = useState(3);
   const [ftp, setFtp] = useState('');
+  const [hours, setHours] = useState('');
+  const [email, setEmail] = useState('');
 
   const handleSubmit = (e) => {
     e.preventDefault();
     const parsedFtp = parseInt(ftp);
-    onComplete({ level, days, ftp: isNaN(parsedFtp) ? 200 : parsedFtp });
+    const parsedHours = parseFloat(hours);
+    if (!email) {
+      alert('E-mailadres is verplicht');
+      return;
+    }
+    onComplete({
+      level,
+      days,
+      hours: isNaN(parsedHours) ? 5 : parsedHours,
+      ftp: isNaN(parsedFtp) ? 200 : parsedFtp,
+      email,
+    });
   };
 
   return (
@@ -51,6 +64,29 @@ export default function TrainingIntake({ onComplete }) {
             value={ftp}
             onChange={(e) => setFtp(e.target.value)}
             className="w-full border border-gray-300 p-2 rounded"
+          />
+        </div>
+
+        <div>
+          <label className="block text-gray-600 mb-1">Uren beschikbaar per week:</label>
+          <input
+            type="number"
+            value={hours}
+            onChange={(e) => setHours(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded"
+            min="1"
+            step="0.5"
+          />
+        </div>
+
+        <div>
+          <label className="block text-gray-600 mb-1">E-mailadres:</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full border border-gray-300 p-2 rounded"
+            required
           />
         </div>
 


### PR DESCRIPTION
## Summary
- inline React, ReactDOM, Babel and Tailwind via CDN
- implement multi-step intake form that collects email and training info
- generate polarized 6-week schedule with varied workouts and per-session TSS
- allow .TCX download for each workout

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*
