### PR TITLE
Add accessible info tooltip

### DIFF
--- a/src/InfoTooltip.jsx
+++ b/src/InfoTooltip.jsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react'
+
+export default function InfoTooltip({ title }) {
+  const [open, setOpen] = useState(false)
+  const hide = () => setOpen(false)
+  return (
+    <span className="relative inline-block ml-1">
+      <button
+        type="button"
+        className="text-blue-600 focus:outline-none"
+        onClick={() => setOpen((o) => !o)}
+        onFocus={() => setOpen(true)}
+        onBlur={hide}
+        aria-label={title}
+        title={title}
+      >
+        ℹ️
+      </button>
+      {open && (
+        <div
+          role="tooltip"
+          className="absolute z-10 mt-2 p-2 text-sm text-white bg-gray-800 rounded"
+        >
+          {title}
+        </div>
+      )}
+    </span>
+  )
+}

--- a/src/TrainingIntake.jsx
+++ b/src/TrainingIntake.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import InfoTooltip from './InfoTooltip.jsx';
 
 export default function TrainingIntake({ onComplete }) {
   const [level, setLevel] = useState('beginner');
@@ -45,7 +46,11 @@ export default function TrainingIntake({ onComplete }) {
         </div>
 
         <div>
-          <label className="block text-gray-600 mb-1">FTP:</label>
+          <label className="block text-gray-600 mb-1 flex items-center">
+            FTP
+            <InfoTooltip title="Functional Threshold Power (FTP) is het maximale vermogen dat je een uur kunt volhouden." />
+            :
+          </label>
           <input
             type="number"
             value={ftp}


### PR DESCRIPTION
## Summary
- create `InfoTooltip` component with button semantics
- use the tooltip next to the FTP label in `TrainingIntake`

## Testing
- `npm run build` *(fails: vite not found)*