### PR TITLE
Add email step and gradient

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply bg-gradient-to-br from-purple-500 via-pink-500 to-red-500 min-h-screen;
+}

--- a/src/SchemaView.jsx
+++ b/src/SchemaView.jsx
@@ -90,15 +90,36 @@ function downloadTcx(title, blocks, ftp) {
   link.click();
 }
 
+function downloadFit(title, blocks, ftp) {
+  const lines = [
+    '# FIT workout placeholder',
+    `Title: ${title}`,
+  ];
+  blocks.forEach((b, i) => {
+    if (b.type === 'interval') {
+      lines.push(
+        `${b.repeats}x ${b.minutes}min @ ${Math.round(ftp * b.factor)}w + ${b.rest}min rust @ ${Math.round(ftp * b.restFactor)}w`
+      );
+    } else {
+      lines.push(`${b.minutes}min @ ${Math.round(ftp * b.factor)}w (${b.type})`);
+    }
+  });
+  const blob = new Blob([lines.join('\n')], { type: 'application/octet-stream' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = `${title.replace(/\s+/g, '_')}.fit`;
+  link.click();
+}
+
 export default function SchemaView({ intake, onUpdateFtp }) {
   const schema = generateSchema(intake);
 
   return (
-    <div className="min-h-screen bg-gray-100 p-6">
+    <div className="min-h-screen bg-gradient-to-br from-purple-500 via-pink-500 to-red-500 p-6">
       <div className="max-w-3xl mx-auto bg-white shadow rounded-lg p-6 space-y-6">
         <h1 className="text-3xl font-bold text-gray-800">Trainingsschema</h1>
         <p className="text-gray-600">
-          Niveau: <strong>{intake.level}</strong> · Dagen/week: <strong>{intake.days}</strong> · FTP: <strong>{intake.ftp} watt</strong>
+          Email: <strong>{intake.email}</strong> · Niveau: <strong>{intake.level}</strong> · Dagen/week: <strong>{intake.days}</strong> · Tijd: <strong>{intake.time}u</strong> · Gewicht: <strong>{intake.weight} kg</strong> · FTP: <strong>{intake.ftp} watt</strong>
         </p>
 
         <div className="grid gap-4">
@@ -120,6 +141,12 @@ export default function SchemaView({ intake, onUpdateFtp }) {
                 className="mt-3 inline-block bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
               >
                 Download .TCX
+              </button>
+              <button
+                onClick={() => downloadFit(item.title, item.blocks, intake.ftp)}
+                className="mt-3 ml-2 inline-block bg-purple-600 text-white px-4 py-2 rounded hover:bg-purple-700"
+              >
+                Download .FIT
               </button>
             </div>
           ))}

--- a/src/TrainingIntake.jsx
+++ b/src/TrainingIntake.jsx
@@ -1,64 +1,138 @@
 import React, { useState } from 'react';
 
 export default function TrainingIntake({ onComplete }) {
+  const [step, setStep] = useState(1);
+  const [email, setEmail] = useState('');
   const [level, setLevel] = useState('beginner');
   const [days, setDays] = useState(3);
+  const [time, setTime] = useState(5);
   const [ftp, setFtp] = useState('');
+  const [weight, setWeight] = useState('');
+  const [error, setError] = useState('');
+
+  const handleNext = (e) => {
+    e.preventDefault();
+    setStep(2);
+  };
 
   const handleSubmit = (e) => {
     e.preventDefault();
     const parsedFtp = parseInt(ftp);
-    onComplete({ level, days, ftp: isNaN(parsedFtp) ? 200 : parsedFtp });
+    const parsedWeight = parseFloat(weight);
+
+    if (
+      !isNaN(parsedFtp) &&
+      parsedWeight > 0 &&
+      parsedFtp / parsedWeight > 5
+    ) {
+      setError('FTP per kg lijkt erg hoog');
+      return;
+    }
+
+    setError('');
+    onComplete({
+      email,
+      level,
+      days,
+      time,
+      ftp: isNaN(parsedFtp) ? 200 : parsedFtp,
+      weight: isNaN(parsedWeight) ? 0 : parsedWeight,
+    });
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-500 via-pink-500 to-red-500">
       <form
-        onSubmit={handleSubmit}
+        onSubmit={step === 1 ? handleNext : handleSubmit}
         className="bg-white p-8 rounded shadow-md w-full max-w-md space-y-6"
       >
         <h2 className="text-2xl font-bold text-center text-gray-700">Trainingsintake</h2>
 
-        <div>
-          <label className="block text-gray-600 mb-1">Niveau:</label>
-          <select
-            value={level}
-            onChange={(e) => setLevel(e.target.value)}
-            className="w-full border border-gray-300 p-2 rounded"
-          >
-            <option value="beginner">Beginner</option>
-            <option value="intermediate">Gevorderd</option>
-            <option value="advanced">Expert</option>
-          </select>
-        </div>
+        {step === 1 && (
+          <>
+            <div>
+              <label className="block text-gray-600 mb-1">E-mail:</label>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                className="w-full border border-gray-300 p-2 rounded"
+              />
+            </div>
+          </>
+        )}
 
-        <div>
-          <label className="block text-gray-600 mb-1">Dagen per week:</label>
-          <input
-            type="number"
-            value={days}
-            onChange={(e) => setDays(Number(e.target.value))}
-            className="w-full border border-gray-300 p-2 rounded"
-            min="1"
-            max="7"
-          />
-        </div>
+        {step === 2 && (
+          <>
+            <div>
+              <label className="block text-gray-600 mb-1">Niveau:</label>
+              <select
+                value={level}
+                onChange={(e) => setLevel(e.target.value)}
+                className="w-full border border-gray-300 p-2 rounded"
+              >
+                <option value="beginner">Beginner</option>
+                <option value="intermediate">Gevorderd</option>
+                <option value="advanced">Expert</option>
+              </select>
+            </div>
 
-        <div>
-          <label className="block text-gray-600 mb-1">FTP:</label>
-          <input
-            type="number"
-            value={ftp}
-            onChange={(e) => setFtp(e.target.value)}
-            className="w-full border border-gray-300 p-2 rounded"
-          />
-        </div>
+            <div>
+              <label className="block text-gray-600 mb-1">Dagen per week:</label>
+              <input
+                type="number"
+                value={days}
+                onChange={(e) => setDays(Number(e.target.value))}
+                className="w-full border border-gray-300 p-2 rounded"
+                min="1"
+                max="7"
+              />
+            </div>
+
+            <div>
+              <label className="block text-gray-600 mb-1">Beschikbare tijd (u/pw):</label>
+              <input
+                type="number"
+                value={time}
+                onChange={(e) => setTime(Number(e.target.value))}
+                className="w-full border border-gray-300 p-2 rounded"
+                min="1"
+              />
+            </div>
+
+            <div>
+              <label className="block text-gray-600 mb-1">FTP:</label>
+              <input
+                type="number"
+                value={ftp}
+                onChange={(e) => setFtp(e.target.value)}
+                className="w-full border border-gray-300 p-2 rounded"
+              />
+            </div>
+
+            <div>
+              <label className="block text-gray-600 mb-1">Gewicht (kg):</label>
+              <input
+                type="number"
+                value={weight}
+                onChange={(e) => setWeight(e.target.value)}
+                className="w-full border border-gray-300 p-2 rounded"
+                min="1"
+              />
+            </div>
+
+            {error && (
+              <p className="text-red-600 text-sm">{error}</p>
+            )}
+          </>
+        )}
 
         <button
           type="submit"
           className="w-full bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600"
         >
-          Genereer Schema
+          {step === 1 ? 'Volgende' : 'Genereer Schema'}
         </button>
       </form>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply bg-gradient-to-br from-purple-500 via-pink-500 to-red-500 min-h-screen;
+}


### PR DESCRIPTION
## Summary
- add page-wide gradient styling
- revise intake form: first step asks email; second step collects training details
- show email and available training time in schema view
- provide placeholder `.fit` workout download

## Testing
- `npm run build` *(fails: vite not found)*